### PR TITLE
Fixes problem with non-dogescript symbols in loops and ifs

### DIFF
--- a/lib/parser.js
+++ b/lib/parser.js
@@ -171,7 +171,7 @@ module.exports = function parse (line) {
                 statement += ' || ';
                 continue;
             }
-            statement += keys[i];
+            statement += keys[i] + ' ';
         }
         statement += ') {\n'
     }
@@ -194,7 +194,7 @@ module.exports = function parse (line) {
                 statement += ' || ';
                 continue;
             }
-            statement += keys[i];
+            statement += keys[i] + ' ';
         }
         statement += ') {\n'
     }
@@ -238,7 +238,7 @@ module.exports = function parse (line) {
                 statement += ' var '
                 continue;
             }
-            statement += keys[i];
+            statement += keys[i] + ' ';
         }
         statement += ') {\n'
     }


### PR DESCRIPTION
Things that were not specified in the if/while/for definitions would be concatenated which could lead to undefined behaviour.

Examples:
many woof > 3
produces 
while (woof>3)

many woof woof 
produces 
while (woofwoof)

The former works but isn't inline with the rest of the syntax. Plus the latter, whilst incorrect even when parsed correctly, isn't parsing correctly.

This fixes that.
