### PR TITLE
properly replace dogeument and windoge

### DIFF
--- a/lib/parser.js
+++ b/lib/parser.js
@@ -1,6 +1,9 @@
 var multiComment = false;
 
 module.exports = function parse (line) {
+    //replace dogeument and windoge always
+    line = line.replace(/dogeument/g, 'document').replace(/windoge/g, 'window');
+
     var keys = line.match(/'[^']+'|\S+/g);
     var valid = ['such', 'wow', 'wow&', 'plz', '.plz', 'dose', 'very', 'shh', 'quiet', 'loud', 'rly', 'but', 'many', 'much', 'so', 'trained'];
     var validKeys = {'is': ' === ', 'not': ' !== ', 'and':  ' && ', 'or':  ' || ', 'next':  '; ', 'as':  ' = ', 'more':  ' += ', 'less':  ' -= ', 'lots': ' *= ', 'few': ' /= ', 'very': ' var ', 'smaller': ' < ', 'bigger': ' > ', 'smallerish': ' <= ', 'biggerish': ' >= ', 'notrly': ' ! '};
@@ -10,11 +13,6 @@ module.exports = function parse (line) {
 
     // not dogescript, such javascript
     if (valid.indexOf(keys[0]) === -1 && keys[1] !== 'is' && keys[1] !== 'dose' || multiComment && keys[0] !== 'loud') return line + '\n';
-    
-    for (var i = 0; i < keys.length; i++) {
-        keys[i] = keys[i].replace('dogeument', 'document');
-        keys[i] = keys[i].replace('windoge', 'window');
-    }
 
     // trained use strict
     if (keys[0] === 'trained') {


### PR DESCRIPTION
Using the following code example:

``` js
$(dogeument).ready(function() {

});
```

`dogeument` is not replaced since the line is not detected to be dogescript. This PR modifies dogescript to always replace dogeument/windoge in the line.
