### PR TITLE
Fixed Node Example

### DIFF
--- a/example/example.djs
+++ b/example/example.djs
@@ -71,11 +71,11 @@ module.exports is woof
 
 shh example http server
 so http
-http dose createServer with much req res
-   req dose writeHead with 200 {'Content-Type': 'text/plain'}
-   req dose end with 'so hello\nmuch world'
+server is http dose createServer with much request response
+  response dose writeHead with 200 {"Content-Type": "text/plain"}
+  response dose end with "hello world"
 wow&
-.plz listen with 8080
+server dose listen with 80 'localhost'
 
 windoge.doge is 'so global, no scope wow'
 very dogelement is plz dogeument.createElement with 'doge'


### PR DESCRIPTION
Error beforehand:

C:\Users\me\Documents\compiled.js:28
req.writeHead(200, {'Content-Type': 'text/plain'});
    ^
TypeError: Object #<IncomingMessage> has no method 'writeHead'
    at Server.<anonymous> (C:\Users\me\Documents\compiled.js:28:5)
    at Server.EventEmitter.emit (events.js:98:17)
    at HTTPParser.parser.onIncoming (http.js:2108:12)
    at HTTPParser.parserOnHeadersComplete [as onHeadersComplete](http.js:121:23)
    at Socket.socket.ondata (http.js:1966:22)
    at TCP.onread (net.js:525:27)
