### PR TITLE
added dogescript-loader to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,11 @@ Options:
 ### Projects using dogescript
 
 - [Doge Adventure!](https://github.com/ngscheurich/doge-adventure): A text adventure game inspired by [leonsumbitches](http://dailydoge.tumblr.com/post/21839788086/leonsumbitches-you-have-encountered-a-doge).
-- [dogeify](https://github.com/remixz/dogeify): A Browserify transform for dogescript.
-- [grunt-dogescript](https://github.com/Bartvds/grunt-dogescript): A grunt plugin to compile dogescript.
 - [Doge Game of Life](https://github.com/eerwitt/doge-game-of-life): Conway's Game of Life in dogescript.
-- [require-doge](https://github.com/Bartvds/require-doge): Directly require() dogescript .djs files in node.
+
+### Tools to compile dogescript
+
+- [dogeify](https://github.com/remixz/dogeify): A [Browserify](http://browserify.org/) transform for dogescript, also usable in [Gulp](https://github.com/gulpjs/gulp)
+- [dogescript-loader](https://github.com/Bartvds/dogescript-loader): A [Webpack](https://Webpack.github.io) loader to bundle dogescript modules.
+- [grunt-dogescript](https://github.com/Bartvds/grunt-dogescript): A [Grunt](http://gruntjs.com) plugin to compile dogescript.
+- [require-doge](https://github.com/Bartvds/require-doge): Directly require() dogescript .djs files in [node.js](http://www.nodejs.org).


### PR DESCRIPTION
I like Webpack more then Browserify so there had to be a dogescript-loader

also I edited the section:
- split projects & compilers into two sections
- linked build modules to tool project pages
- added Gulp note to dogify item description
