### PR TITLE
cleanup so-statement

### DIFF
--- a/lib/parser.js
+++ b/lib/parser.js
@@ -255,7 +255,7 @@ module.exports = function parse (line) {
         if (keys[2] === 'as') {
             statement += 'var ' + keys[3] + ' = require(\'' + keys[1] + '\');\n';
         } else {
-            statement += 'var ' + keys[1] + ' = require(\'' + keys[1] + '\');\n';
+            statement += 'var ' + keys[1].replace(/\.\w+$/, '').replace(/-/g, '_') + ' = require(\'' + keys[1] + '\');\n';
         }
     }
 


### PR DESCRIPTION
this would simplyify require()-ing with dogify/dogescript-require/dogescript-loader

only for simple so, not for so-as

trim extension from require for variable name

```
so foo.djs
//
var foo = require('foo.djs');
```

replace dash with underscore

```
so loader-utils
//
var loader_utils = require('loader-utils);
```
