### PR TITLE
--beautify missing last new line fixed

### DIFF
--- a/bin/dogescript.js
+++ b/bin/dogescript.js
@@ -19,7 +19,7 @@ if (argv._[0]) {
             output += parser(lines[i]);
         }
 
-        if (argv.beautify) process.stdout.write(beautify(output, {break_chained_methods: false}))
+        if (argv.beautify) process.stdout.write(beautify(output, {break_chained_methods: false}) + '\n');
         else process.stdout.write(output);
     });
 } else {


### PR DESCRIPTION
Before, using the `--beautify` option, the generated file didn't have a last new line
