### PR TITLE
support loading of dogescript files in REPL

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,32 @@ Options:
 * `beauty` - A boolean, set to true if you want the output to be ran through a beautifier.
 * `trueDoge` - A boolean, set to true if you want to enable true-doge mode. *Deprecated in 2.4.0, to be removed in 3.0.0*
 
+#### REPL Commands
+
+* `.load-doge [path_to_doge]`: loads dogescript code in the given file and adds it to the REPL environment. For this example, *iota* is a function that produces a series from 0 to n, ie: `iota 5 => [0,1,2,3,4]`, and is defined in `repl-test/iota.djs`.
+```bash
+DOGE> .load-doge repl-test/iota.djs
+DOGE> undefined
+DOGE> plz iota with 5
+[ 0, 1, 2, 3, 4 ]
+DOGE>
+```
+
+### Developer versions
+
+If you wish to take your dogescript to the moon and leave at the edge of amaze, you can install the dogescript version as it exists in this repository:
+
+1. `npm install` the repository
+1. link the newer version with `npm link`
+1. Verify by running `dogescript`, something like the following should show up (version # might be different but the pre syntax will still be there):
+```bash
+$ dogescript
+[dogescript@2.4.0-pre]
+DOGE>
+```
+1. To restore, navigate out of the dogescript repository and reinstall an earlier version:
+`npm install dogescript@2.3.0 -g`
+
 ### Language documentation
 
 * [`LANGUAGE.md`](/LANGUAGE.md)

--- a/README.md
+++ b/README.md
@@ -43,29 +43,14 @@ Options:
 
 #### REPL Commands
 
-* `.load-doge [path_to_doge]`: loads dogescript code in the given file and adds it to the REPL environment. For this example, *iota* is a function that produces a series from 0 to n, ie: `iota 5 => [0,1,2,3,4]`, and is defined in `repl-test/iota.djs`.
+* `.plz-load [path_to_doge]`: loads dogescript code in the given file and adds it to the REPL environment. For this example, *iota* is a function that produces a series from 0 to n, ie: `iota 5 => [0,1,2,3,4]`, and is defined in `repl-test/iota.djs`.
 ```bash
-DOGE> .load-doge repl-test/iota.djs
+DOGE> .plz-doge repl-test/iota.djs
 DOGE> undefined
 DOGE> plz iota with 5
 [ 0, 1, 2, 3, 4 ]
 DOGE>
 ```
-
-### Developer versions
-
-If you wish to take your dogescript to the moon and leave at the edge of amaze, you can install the dogescript version as it exists in this repository:
-
-1. `npm install` the repository
-1. link the newer version with `npm link`
-1. Verify by running `dogescript`, something like the following should show up (version # might be different but the pre syntax will still be there):
-```bash
-$ dogescript
-[dogescript@2.4.0-pre]
-DOGE>
-```
-1. To restore, navigate out of the dogescript repository and reinstall an earlier version:
-`npm install dogescript@2.3.0 -g`
 
 ### Language documentation
 

--- a/bin/dogescript.js
+++ b/bin/dogescript.js
@@ -8,9 +8,11 @@ var repl     = require('repl');
 var argv     = require('optimist').usage('Usage: dogescript <file>').argv;
 var beautify = require('js-beautify').js_beautify;
 var parser   = require('../lib/parser');
+var pjson = require('../package.json');
 
-// display version message, keep pre for dev
-process.stdout.write("[dogescript@2.4.0-pre]\n");
+
+// display version message
+process.stdout.write("[dogescript@"+pjson.version+"]\n");
 
 if (argv._[0]) {
     var file = fs.readFile(path.resolve(process.cwd(), argv._[0]), {encoding: 'utf-8'}, function (err, script) {
@@ -53,7 +55,7 @@ if (argv._[0]) {
         output : process.stdout
     });
     
-    replServer.defineCommand('load-doge', {
+    replServer.defineCommand('plz-load', {
       help: 'Loads a dogescript file into the repl',
       action(filename) {
          var file = fs.readFile(path.resolve(process.cwd(), filename), {encoding: 'utf-8'}, function (err, script) {

--- a/bin/dogescript.js
+++ b/bin/dogescript.js
@@ -9,6 +9,9 @@ var argv     = require('optimist').usage('Usage: dogescript <file>').argv;
 var beautify = require('js-beautify').js_beautify;
 var parser   = require('../lib/parser');
 
+// display version message, keep pre for dev
+process.stdout.write("[dogescript@2.4.0-pre]\n");
+
 if (argv._[0]) {
     var file = fs.readFile(path.resolve(process.cwd(), argv._[0]), {encoding: 'utf-8'}, function (err, script) {
         if (argv['true-doge']) var lines = script.split(/ {3,}|\r?\n/);
@@ -43,10 +46,29 @@ if (argv._[0]) {
 
     var ds = new Stream();
     // pipe stdin through the dogescript translator to the repl
-    repl.start({
+    // can't use options.eval with a custom eval function since the javascript evaluator reference gets overwritten and defaultEval is not accessible
+    const replServer = repl.start({
         prompt : "DOGE> ",
         input  : ds,
         output : process.stdout
+    });
+    
+    replServer.defineCommand('load-doge', {
+      help: 'Loads a dogescript file into the repl',
+      action(filename) {
+         var file = fs.readFile(path.resolve(process.cwd(), filename), {encoding: 'utf-8'}, function (err, script) {
+          if (argv['true-doge']) var lines = script.split(/ {3,}|\r?\n/);
+          else var lines = script.split(/\r?\n/);
+          replServer.editorMode = true;
+          for (var i = 0; i < lines.length; i++) {
+              replServer.write(parser(lines[i]));
+          }
+          replServer.editorMode = false;
+          replServer.write('\n');
+         });
+         
+        this.displayPrompt();
+      }
     });
 
     // begin streaming stdin to the dg translator and repl

--- a/repl-test/iota.djs
+++ b/repl-test/iota.djs
@@ -1,0 +1,4 @@
+such iota much n
+  very series is Array dose apply with null {length:n}&
+  dose map with Number.call Number
+wow series


### PR DESCRIPTION
Adds a `load-doge` command to the REPL so users can load their dogescript code into the environment. 

You can verify this worked by doing the following:

1. Install the dev version of dogescript (`npm install`). 
1. Link the new version, running `npm link` from within the repository

Running dogescript should now output a version message with the tag `pre`:
```bash
$ dogescript
[dogescript@2.4.0-pre]
DOGE>
```

To load a file, use `.load-doge [file]`:
```bash
DOGE> .load-doge repl-test/iota.djs
DOGE> undefined
DOGE> plz iota with 5
[ 0, 1, 2, 3, 4 ]
DOGE>
```