### PR TITLE
update doge-toe link

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ DOGE>
 
 * [Doge Adventure!](https://github.com/ngscheurich/doge-adventure): A text adventure game inspired by [leonsumbitches](http://dailydoge.tumblr.com/post/21839788086/leonsumbitches-you-have-encountered-a-doge).
 * [Doge Game of Life](https://github.com/eerwitt/doge-game-of-life): Conway's Game of Life in dogescript.
-* [doge-toe](http://alexdantas.net/games/doge-toe/): Tic-Tac-Toe in dogescript.
+* [doge-toe](https://github.com/alexdantas/doge-toe): Tic-Tac-Toe in dogescript.
 
 ### Utilities
 


### PR DESCRIPTION
The current doge-toe link goes to malware (looks like @alexdantas lost his domain). Updated it to point straight to the repository instead!