### PR TITLE
refactor check for djs source

### DIFF
--- a/lib/parser.js
+++ b/lib/parser.js
@@ -70,6 +70,52 @@ function containsUnary(keys)
   return unaryOps.hasOwnProperty(keys[0]) || unaryOps.hasOwnProperty(keys[1]);
 }
 
+/**
+ * Determines if the parsed keys should be treated as dogescript source or not.
+ */
+function isDogescriptSource(keys)
+{
+
+  // starts the statement with a valid key
+  if (valid.indexOf(keys[0]) !== -1)
+  {
+    return true;
+  }
+
+  // statement applying an assignment operator
+  if ( assignOps.hasOwnProperty(keys[1]) )
+  {
+    return true;
+  }
+
+  // applying a unary operator
+  if ( containsUnary(keys) )
+  {
+    return true;
+  }
+
+  // calling function on Object
+  if ( keys[1] === 'dose' )
+  {
+    return true;
+  }
+
+  // ending a multi comment block
+  if (multiComment && keys[0] === 'loud' )
+  {
+    return true;
+  }
+
+  // closing a multi-line object creation
+  if ( multiLine && keys[0] === 'wow' )
+  {
+    return true;
+  }
+
+  // not valid dogescript
+  return false;
+}
+
 var replacements = {};
 replacements['dogeument']='document'
 replacements['windoge']='window'
@@ -89,7 +135,7 @@ module.exports = function parse (line) {
     if (keys === null) return line + '\n';
 
     // not dogescript, such javascript
-    if (valid.indexOf(keys[0]) === -1 && !assignOps.hasOwnProperty(keys[1]) && !containsUnary(keys) && keys[1] !== 'dose' || multiComment && keys[0] !== 'loud' || multiLine && keys[0] !== 'wow')
+    if ( !isDogescriptSource(keys) )
     {
       return line + '\n';
     }


### PR DESCRIPTION
We have a long if-statement to determine if a line should be parsed as dogescript source or not:
```
 if (valid.indexOf(keys[0]) === -1 && !assignOps.hasOwnProperty(keys[1]) && !containsUnary(keys) && keys[1] !== 'dose' || multiComment && keys[0] !== 'loud' || multiLine && keys[0] !== 'wow')
```

This sort of makes it hard to extend and reason (thinking about `class` support). 

Hopefully the new function makes it easier to determine why we thought something was djs and lets us more easily add conditions.