### PR TITLE
update woof to consume tokens

### DIFF
--- a/lib/parser.js
+++ b/lib/parser.js
@@ -128,36 +128,46 @@ function isDogescriptSource(keys)
   return false;
 }
 
+/**
+ * Handles the woof construct:
+ *  woof <alias> be <export>
+ *  woof <export>
+ *
+ * Produces:
+ *  module.exports.alias = export
+ *  module.exports = export
+ */
 function handleWoof(keys)
 {
+  expectToken('woof', keys);
 
-  // woof foo is X
+  // look ahead and check if it is in `woof x be y` form
   if ( keys[2] === 'be' )
   {
+    // woof foo is X -> module.exports.foo = X
     return handleNamedWoof(keys);
   }
+
+  // consume: woof
+  keys.shift();
 
   // module.exports = SOMETHING
   var statement = '';
   statement += 'module.exports = ';
 
+  var assignmentValue = keys[0];
   // woof something -> module.exports = something
-  if( keys.length == 2)
+  if( keys.length === 1)
   {
-    var exportedFunction = keys[1];
-    statement += keys[1];
+    statement += assignmentValue;
     statement += '\n';
     return statement;
   }
 
-  var assignmentValue = keys[1];
-
   // module.exports = function x(a,b) {}
   if ( assignmentValue === 'such' )
   {
-    // shift tokens
-    var funcKeys = keys.slice(1);
-    var functionStatement = handleSuch(funcKeys);
+    var functionStatement = handleSuch(keys);
     statement += functionStatement;
     // the closing wow will be in a new line
     return statement;
@@ -166,33 +176,42 @@ function handleWoof(keys)
   // module.exports = function (a,b) {}
   if ( assignmentValue === 'much')
   {
-    // shift tokens
-    var anonKeys = keys.slice(1);
-    var anonStatement = handleLambda(anonKeys);
+    var anonStatement = handleLambda(keys);
     statement += anonStatement;
     // the closing wow will be in a new line
     return statement;
   }
 
   // TODO support other expressions
-  throw new Error("Unparseable syntax: " + keys);
+  throw new Error(`Invalid parse state! Expected a value but got: '${keys[0]}' from chain: [${keys}]. Allowed construct 'woof <name> be [value | <SUCH> | <MUCH> ]'`);
 }
 
-// module.exports.foo = SOMETHING
+/**
+ * Handles the woof construct with a name:
+ *  woof <alias> be <export>
+ *
+ * Produces:
+ *  module.exports.alias = export
+ */
 function handleNamedWoof(keys)
 {
+  expectToken('woof', keys);
 
-  var exportName = keys[1];
+  // consume: woof
+  keys.shift();
+
+  var exportName = keys.shift();
   var statement = 'module.exports.' + exportName + ' = '
 
-  var assignmentValue = keys[3];
+  // consume: be
+  keys.shift();
+
+  var assignmentValue = keys[0];
 
   // module.exports.foo = function x(a,b) {}
   if ( assignmentValue === 'such' )
   {
-    // shift tokens
-    var funcKeys = keys.slice(3);
-    var functionStatement = handleSuch(funcKeys);
+    var functionStatement = handleSuch(keys);
     statement += functionStatement;
     // the closing wow will be in a new line
     return statement;
@@ -201,23 +220,20 @@ function handleNamedWoof(keys)
   // module.exports.foo = function (a,b) {}
   if ( assignmentValue === 'much')
   {
-    // shift tokens
-    var anonKeys = keys.slice(3);
-    var anonStatement = handleLambda(anonKeys);
+    var anonStatement = handleLambda(keys);
     statement += anonStatement;
     // the closing wow will be in a new line
     return statement;
   }
 
   // TODO support module.exports.foo = something dose something / plz do something / bar is baz
-  if(keys.length > 4)
+  if(keys.length > 1)
   {
     throw new Error("Unparseable syntax: " + keys);
   }
 
   // module.exports.foo = bar
-  var funcName = keys[3];
-  statement += funcName;
+  statement += assignmentValue;
   statement += '\n';
   return statement;
 }
@@ -791,7 +807,7 @@ module.exports = function parse (line) {
 
     if(keys[0] === 'woof')
     {
-      statement += handleWoof(keys);
+      return handleWoof(keys);
     }
 
     return statement;


### PR DESCRIPTION
Updates the `woof` handler to consume tokens as it parses. Since `woof` should consume all tokens to the right, we can return the result. 