### PR TITLE
make so consume tokens

### DIFF
--- a/lib/parser.js
+++ b/lib/parser.js
@@ -290,28 +290,35 @@ function handleLambda(keys)
 }
 
 /**
- * Handles the so construct: (thanks @maxogden!):
- * so lib [as name]
+ * Handles the so construct (thanks @maxogden!):
+ *  so <module> [as <name>]
+ *
+ * Produces:
+ *  var name = require('module');
  */
 function handleSo(keys)
 {
   expectToken('so', keys);
 
+  // consume: so
+  keys.shift();
+
   var statement = '';
-  var lib = keys[1];
+  var lib = keys.shift();
 
   var modName = '';
 
-  // so x as [modName]
-  if (keys.length > 2)
-  {
-    modName = keys[3]
-  }
-  else {
+  // check if it's a named import or not
+  if(keys.length > 0) {
+    expectToken('as', keys);
+    // consume: as
+    keys.shift();
+    modName = keys.shift();
+  } else {
     // so x
 
     // try to make a simple name
-    var mod = keys[1];
+    var mod = lib;
     // test for relative module, optional chop extension
     var m = /^..?\/.*?([\w-]+)(\.\w+)?$/.exec(mod);
     if (m) {
@@ -762,9 +769,9 @@ module.exports = function parse (line) {
         statement += ') {\n';
     }
 
-    // so require (thanks @maxogden!)
+    // so require
     if (keys[0] === 'so') {
-        statement += handleSo(keys);
+      return handleSo(keys);
     }
 
     // maybe boolean operator


### PR DESCRIPTION
Updates the `so` handler to consume tokens as it parses. Since `so` should consume all tokens to the right, we can return the result instead of letting it trickle down.