### PR TITLE
consume tokens for comment ops

### DIFF
--- a/lib/parser.js
+++ b/lib/parser.js
@@ -99,6 +99,21 @@ function expectAnyToken(expectedTokens, tokens)
   }
 }
 
+/**
+ * Joins the set of keys into a string beginning with a " " such that joinTokens([a, b]) returns " a b"
+ */
+function joinTokens(keys)
+{
+  var tokenString = '';
+
+  while(token = keys.shift())
+  {
+    tokenString += ' ' + token;
+  }
+
+  return tokenString;
+}
+
 function containsUnary(keys)
 {
   return unaryOps.hasOwnProperty(keys[0]) || unaryOps.hasOwnProperty(keys[1]);
@@ -371,15 +386,19 @@ function handleSo(keys)
 /**
  * Handles the single line comment:
  * shh [text]
+ *
+ * Produces:
+ * // text
  */
 function handleShh(keys)
 {
   expectToken('shh', keys);
 
+  // consume: shh
+  keys.shift();
+
   var statement = '//';
-  for (var i = 1; i < keys.length; i++) {
-      statement += ' ' + keys[i];
-  }
+  statement += joinTokens(keys);
   statement += '\n';
 
   return statement;
@@ -388,16 +407,20 @@ function handleShh(keys)
 /**
  * Handles the beginning of a multi-line comment:
  * quiet [comments]
+ *
+ * Produces the start of a multi-line comment "/*"
  */
  function handleQuiet(keys)
  {
    expectToken('quiet', keys);
 
-   var statement = '/*';
+   // consume: quiet
+   keys.shift();
+
    multiComment = true;
-   for (var i = 1; i < keys.length; i++) {
-       statement += ' ' + keys[i];
-   }
+
+   var statement = '/*';
+   statement += joinTokens(keys);
    statement += '\n';
 
    return statement;
@@ -406,21 +429,27 @@ function handleShh(keys)
 /**
  * Handles the end of the multi-line comment:
  * loud
+ *
+ * Produces the end of a multiline comment "*\/"
  */
 function handleLoud(keys)
 {
   expectToken('loud', keys);
+
   if(!multiComment)
   {
     throw new Error("Unparseable syntax! Encountered: 'loud' without first seeing 'quiet'");
   }
 
-  var statement = '*/';
+  // consume: loud
+  keys.shift();
+
   multiComment = false;
-  for (var i = 1; i < keys.length; i++) {
-      statement += ' ' + keys[i];
-  }
+
+  var statement = '*/';
+  statement += joinTokens(keys);
   statement += '\n';
+
   return statement;
 }
 
@@ -794,12 +823,12 @@ module.exports = function parse (line) {
 
     // shh comment
     if (keys[0] === 'shh') {
-        statement += handleShh(keys);
+      return handleShh(keys);
     }
 
     // quiet start multi-line comment
     if (keys[0] === 'quiet') {
-        statement += handleQuiet(keys);
+      return handleQuiet(keys);
     }
 
     // rly if


### PR DESCRIPTION
updates `shh`, `quiet` `loud` to consume tokens as they parse. 