### PR TITLE
make control flow consume tokens

### DIFF
--- a/lib/parser.js
+++ b/lib/parser.js
@@ -505,8 +505,11 @@ function handleRly(keys)
 {
   expectToken('rly', keys);
 
+  // consume: rly
+  keys.shift();
+
   var statement = 'if ('
-  statement += controlFlowParser(1,keys);
+  statement += controlFlowParser(keys);
   // close condition and open branch
   statement += ') {\n';
   return statement;
@@ -520,8 +523,11 @@ function handleNotrly(keys)
 {
   expectToken('notrly', keys);
 
+  // consume: notrly
+  keys.shift();
+
   var statement = 'if (!';
-  statement += controlFlowParser(1, keys);
+  statement += controlFlowParser(keys);
   // close condition and open branch
   statement += ') {\n';
   return statement;
@@ -536,18 +542,18 @@ function handleBut(keys)
 {
   expectToken('but', keys);
 
-  var statement = '} else ';
-  if (keys[1] === 'rly' || keys[1] === 'notrly' )
-  {
-    // shift tokens
-    var innerKeys = keys.slice(1);
+  // consume: but
+  keys.shift();
 
-    if(innerKeys[0] === 'rly' )
+  var statement = '} else ';
+  if (keys[0] === 'rly' || keys[0] === 'notrly' )
+  {
+    if(keys[0] === 'rly' )
     {
-      statement += handleRly(innerKeys);
+      statement += handleRly(keys);
     }
     else {
-      statement += handleNotrly(innerKeys);
+      statement += handleNotrly(keys);
     }
   }
   else
@@ -637,17 +643,20 @@ function handleWith(keys)
  * Handles inner parsing from control flow statements:
  * rly notrly but much many
  */
-function controlFlowParser(keyStart, keys)
+function controlFlowParser(keys)
 {
   var statement = '';
 
-  for (var i = keyStart; i < keys.length; i++) {
+  while(token = keys.shift())
+  {
     // convert to supported operators (eventually this will just call parse again)
-    if (validOperators.hasOwnProperty(keys[i])) {
-      statement += validOperators[keys[i]];
+    if(validOperators.hasOwnProperty(token))
+    {
+      statement += validOperators[token];
     }
-    else {
-      statement += keys[i] + ' ';
+    else
+    {
+      statement += token + ' ';
     }
   }
 
@@ -706,8 +715,11 @@ function handleMuchLoop(keys)
 {
   expectToken('much', keys);
 
+  // consume: much
+  keys.shift();
+
   var statement = 'for ('
-  statement += controlFlowParser(1,keys);
+  statement += controlFlowParser(keys);
   statement += ') {\n';
   return statement;
 }
@@ -723,8 +735,11 @@ function handleMany(keys)
 {
   expectToken('many', keys);
 
+  // consume: many
+  keys.shift();
+
   var statement = 'while (';
-  statement += controlFlowParser(1, keys);
+  statement += controlFlowParser(keys);
   statement += ') {\n';
 
   return statement;
@@ -978,28 +993,28 @@ module.exports = function parse (line) {
 
     // rly if
     if (keys[0] === 'rly') {
-        statement += handleRly(keys);
+      return handleRly(keys);
     }
 
     // ntrly if
     if (keys[0] === 'notrly')
     {
-        statement += handleNotrly(keys);
+      return handleNotrly(keys);
     }
 
     // but else
     if (keys[0] === 'but') {
-        statement += handleBut(keys);
+      return handleBut(keys);
     }
 
     // many while
     if (keys[0] === 'many') {
-        statement += handleMany(keys);
+      return  handleMany(keys);
     }
 
     // much for
     if (keys[0] === 'much') {
-        statement += handleMuchLoop(keys);
+      return handleMuchLoop(keys);
     }
 
     // so require


### PR DESCRIPTION
updates `rly` `notrly` `but` `much` (loop) `many` to consume tokens. 

This will let us remove a safeguard in the assign operator handling code (in a follow up pr): https://github.com/dogescript/dogescript/blob/master/lib/parser.js#L1021