### PR TITLE
combine woof handling

### DIFF
--- a/lib/parser.js
+++ b/lib/parser.js
@@ -189,25 +189,29 @@ function handleWoof(keys)
 {
   expectToken('woof', keys);
 
-  // look ahead and check if it is in `woof x be y` form
-  if ( keys[2] === 'be' )
-  {
-    // woof foo be X -> module.exports.foo = X
-    return handleNamedWoof(keys);
-  }
-
   // consume: woof
   keys.shift();
 
+  var exportName = '';
+
+  // look ahead and check if it is in `woof x be y` form
+  if ( keys[1] === 'be' )
+  {
+    // woof foo be X -> module.exports.foo = X
+    exportName = '.' + keys.shift();
+
+    // consume: be
+    keys.shift();
+  }
+
   // module.exports = SOMETHING
-  var statement = '';
-  statement += 'module.exports = ';
+  var statement = 'module.exports' + exportName + ' = ';
 
   var assignmentValue = keys[0];
   // woof something -> module.exports = something
   if( keys.length === 1)
   {
-    statement += assignmentValue;
+    statement += keys.shift();
     statement += '\n';
     return statement;
   }
@@ -231,59 +235,7 @@ function handleWoof(keys)
   }
 
   // TODO support other expressions
-  throw new Error(`Invalid parse state! Expected a value but got: '${keys[0]}' from chain: [${keys}]. Allowed construct 'woof <name> be [value | <SUCH> | <MUCH> ]'`);
-}
-
-/**
- * Handles the woof construct with a name:
- *  woof <alias> be <export>
- *
- * Produces:
- *  module.exports.alias = export
- */
-function handleNamedWoof(keys)
-{
-  expectToken('woof', keys);
-
-  // consume: woof
-  keys.shift();
-
-  var exportName = keys.shift();
-  var statement = 'module.exports.' + exportName + ' = '
-
-  // consume: be
-  keys.shift();
-
-  var assignmentValue = keys[0];
-
-  // module.exports.foo = function x(a,b) {}
-  if ( assignmentValue === 'such' )
-  {
-    var functionStatement = handleSuch(keys);
-    statement += functionStatement;
-    // the closing wow will be in a new line
-    return statement;
-  }
-
-  // module.exports.foo = function (a,b) {}
-  if ( assignmentValue === 'much')
-  {
-    var anonStatement = handleLambda(keys);
-    statement += anonStatement;
-    // the closing wow will be in a new line
-    return statement;
-  }
-
-  // TODO support module.exports.foo = something dose something / plz do something / bar is baz
-  if(keys.length > 1)
-  {
-    throw new Error("Unparseable syntax: " + keys);
-  }
-
-  // module.exports.foo = bar
-  statement += assignmentValue;
-  statement += '\n';
-  return statement;
+  throw new Error(`Invalid parse state! Expected a value but got: '${keys[0]}' from chain: [${keys}]. Allowed construct 'woof [<name> be] <value | <SUCH> | <MUCH> >'`);
 }
 
 /**


### PR DESCRIPTION
Combines the handling of `woof` and `woof a be` into a single function. While working on making this recursive (over here: https://github.com/AnEmortalKid/dogescript/blob/wip-recurse/lib/parser.js#L213) I noticed that the last statement was not getting consumed (.shift()) . once i had to change it in two places for woof i realized it could be combined :)