### PR TITLE
join instead of returning line

### DIFF
--- a/lib/parser.js
+++ b/lib/parser.js
@@ -883,7 +883,7 @@ module.exports = function parse (line) {
       // consume tokens until we encounter loud
       if(keys[0] !== 'loud')
       {
-        return line + '\n';
+        return joinTokens(keys) + '\n';
       }
       // else must be loud
       return handleLoud(keys);
@@ -892,7 +892,7 @@ module.exports = function parse (line) {
     // not dogescript, such javascript
     if ( !isDogescriptSource(keys) )
     {
-      return line + '\n';
+      return joinTokens(keys) + '\n';
     }
 
     // trained use strict

--- a/test/spec/quiet/commented-djs/expect.js
+++ b/test/spec/quiet/commented-djs/expect.js
@@ -1,3 +1,3 @@
 /*
- very x is y
+very x is y
 */

--- a/test/spec/quiet/multiple-lines/expect.js
+++ b/test/spec/quiet/multiple-lines/expect.js
@@ -1,4 +1,4 @@
 /*
-    silent
-    ninja
+silent
+ninja
 */


### PR DESCRIPTION
Prefer joinTokens instead of returning raw line (eat whitespace). 

Thinking about eventually making certain calls to 'parse' call a different function with the keys (and not an appended line), I wanted to see what would break if we didn't return line. Since a suggestion was made in #166 , if we didn't depend on having to return the line we could fix the tokens not in a regex. 