### PR TITLE
rename keys to tokens

### DIFF
--- a/lib/parser.js
+++ b/lib/parser.js
@@ -37,7 +37,7 @@ var unaryOps = {
 
 var incrementDecrementOps = ['bigify', 'smallify']
 
-var controlFlowKeys = [
+var controlFlowTokens = [
   'many',
   'much',
   'rly',
@@ -103,17 +103,17 @@ function expectAnyToken(expectedTokens, tokens)
 }
 
 /**
- * Joins the set of keys into a string such that joinTokens([a, b]) returns "a b".
- * Consumes all keys from the given array such that the array will be empty if it is referenced after calling this function.
+ * Joins the set of tokens into a string such that joinTokens([a, b]) returns "a b".
+ * Consumes all tokens from the given array such that the array will be empty if it is referenced after calling this function.
  */
-function joinTokens(keys)
+function joinTokens(tokens)
 {
   var tokenString = '';
 
-  while(token = keys.shift())
+  while(token = tokens.shift())
   {
     tokenString += token;
-    if(keys.length > 0)
+    if(tokens.length > 0)
     {
       tokenString += ' ';
     }
@@ -122,57 +122,57 @@ function joinTokens(keys)
   return tokenString;
 }
 
-function containsUnary(keys)
+function containsUnary(tokens)
 {
-  return unaryOps.hasOwnProperty(keys[0]) || unaryOps.hasOwnProperty(keys[1]);
+  return unaryOps.hasOwnProperty(tokens[0]) || unaryOps.hasOwnProperty(tokens[1]);
 }
 
 /**
  * Determines whether the first or second token is one of [bigify, smallify]
  */
-function containsIncrementDecrement(keys)
+function containsIncrementDecrement(tokens)
 {
-  return incrementDecrementOps.indexOf(keys[0]) !== -1 || incrementDecrementOps.indexOf(keys[1]) !== -1;
+  return incrementDecrementOps.indexOf(tokens[0]) !== -1 || incrementDecrementOps.indexOf(tokens[1]) !== -1;
 }
 
 /**
- * Determines if the parsed keys should be treated as dogescript source or not.
+ * Determines if the parsed tokens should be treated as dogescript source or not.
  */
-function isDogescriptSource(keys)
+function isDogescriptSource(tokens)
 {
 
-  // starts the statement with a valid key
-  if (valid.indexOf(keys[0]) !== -1)
+  // starts the statement with a valid token
+  if (valid.indexOf(tokens[0]) !== -1)
   {
     return true;
   }
 
   // statement applying an assignment operator
-  if ( assignOps.hasOwnProperty(keys[1]) )
+  if ( assignOps.hasOwnProperty(tokens[1]) )
   {
     return true;
   }
 
   // applying a unary operator
-  if ( containsUnary(keys) )
+  if ( containsUnary(tokens) )
   {
     return true;
   }
 
   // calling function on Object
-  if ( keys[1] === 'dose' )
+  if ( tokens[1] === 'dose' )
   {
     return true;
   }
 
   // ending a multi comment block
-  if (multiComment && keys[0] === 'loud' )
+  if (multiComment && tokens[0] === 'loud' )
   {
     return true;
   }
 
   // closing a multi-line object creation
-  if ( multiLine && keys[0] === 'wow' )
+  if ( multiLine && tokens[0] === 'wow' )
   {
     return true;
   }
@@ -190,33 +190,33 @@ function isDogescriptSource(keys)
  *  module.exports.alias = export
  *  module.exports = export
  */
-function handleWoof(keys)
+function handleWoof(tokens)
 {
-  expectToken('woof', keys);
+  expectToken('woof', tokens);
 
   // consume: woof
-  keys.shift();
+  tokens.shift();
 
   var exportName = '';
 
   // look ahead and check if it is in `woof x be y` form
-  if ( keys[1] === 'be' )
+  if ( tokens[1] === 'be' )
   {
     // woof foo be X -> module.exports.foo = X
-    exportName = '.' + keys.shift();
+    exportName = '.' + tokens.shift();
 
     // consume: be
-    keys.shift();
+    tokens.shift();
   }
 
   // module.exports = SOMETHING
   var statement = 'module.exports' + exportName + ' = ';
 
-  var assignmentValue = keys[0];
+  var assignmentValue = tokens[0];
   // woof something -> module.exports = something
-  if( keys.length === 1)
+  if( tokens.length === 1)
   {
-    statement += keys.shift();
+    statement += tokens.shift();
     statement += '\n';
     return statement;
   }
@@ -224,7 +224,7 @@ function handleWoof(keys)
   // module.exports = function x(a,b) {}
   if ( assignmentValue === 'such' )
   {
-    var functionStatement = handleSuch(keys);
+    var functionStatement = handleSuch(tokens);
     statement += functionStatement;
     // the closing wow will be in a new line
     return statement;
@@ -233,14 +233,14 @@ function handleWoof(keys)
   // module.exports = function (a,b) {}
   if ( assignmentValue === 'much')
   {
-    var anonStatement = handleLambda(keys);
+    var anonStatement = handleLambda(tokens);
     statement += anonStatement;
     // the closing wow will be in a new line
     return statement;
   }
 
   // TODO support other expressions
-  throw new Error(`Invalid parse state! Expected a value but got: '${keys[0]}' from chain: [${keys}]. Allowed construct 'woof [<name> be] <value | <SUCH> | <MUCH> >'`);
+  throw new Error(`Invalid parse state! Expected a value but got: '${tokens[0]}' from chain: [${tokens}]. Allowed construct 'woof [<name> be] <value | <SUCH> | <MUCH> >'`);
 }
 
 /**
@@ -250,28 +250,28 @@ function handleWoof(keys)
  * Produces:
  *  function <function_name> ([args]) {
  */
-function handleSuch(keys)
+function handleSuch(tokens)
 {
-  expectToken('such', keys);
+  expectToken('such', tokens);
   // consume: such
-  keys.shift();
+  tokens.shift();
 
-  var functionName = keys.shift();
+  var functionName = tokens.shift();
   var statement = 'function ' + functionName;
 
   // no args
-  if (!keys[0])
+  if (!tokens[0])
   {
     return statement + ' () { \n';
   }
 
   // args have to be declared with much
-  if (keys[0] !== 'much')
+  if (tokens[0] !== 'much')
   {
-    throw new Error(`Invalid parse state! Expected: 'much' but got: '${keys[0]}' from chain: [${keys}]. Allowed construct 'such <function_name> [much <args>]'`);
+    throw new Error(`Invalid parse state! Expected: 'much' but got: '${tokens[0]}' from chain: [${tokens}]. Allowed construct 'such <function_name> [much <args>]'`);
   }
 
-  statement += handleMuchArgs(keys);
+  statement += handleMuchArgs(tokens);
   return statement;
 }
 
@@ -285,18 +285,18 @@ function handleSuch(keys)
  * Assuming that the function_name was encountered before this should ultimately produce:
  *  function([args]) {
  */
-function handleMuchArgs(keys)
+function handleMuchArgs(tokens)
 {
-  expectToken('much', keys);
+  expectToken('much', tokens);
 
   // consume: much
-  keys.shift();
+  tokens.shift();
 
   var statement = ' (';
-  while(arg = keys.shift())
+  while(arg = tokens.shift())
   {
     statement += arg;
-    if(keys.length > 0)
+    if(tokens.length > 0)
     {
       statement += ', ';
     }
@@ -313,9 +313,9 @@ function handleMuchArgs(keys)
  * Produces:
  *  function (args) {
  */
-function handleLambda(keys)
+function handleLambda(tokens)
 {
-  return 'function' + handleMuchArgs(keys);
+  return 'function' + handleMuchArgs(tokens);
 }
 
 /**
@@ -325,24 +325,24 @@ function handleLambda(keys)
  * Produces:
  *  var name = require('module');
  */
-function handleSo(keys)
+function handleSo(tokens)
 {
-  expectToken('so', keys);
+  expectToken('so', tokens);
 
   // consume: so
-  keys.shift();
+  tokens.shift();
 
   var statement = '';
-  var lib = keys.shift();
+  var lib = tokens.shift();
 
   var modName = '';
 
   // check if it's a named import or not
-  if(keys.length > 0) {
-    expectToken('as', keys);
+  if(tokens.length > 0) {
+    expectToken('as', tokens);
     // consume: as
-    keys.shift();
-    modName = keys.shift();
+    tokens.shift();
+    modName = tokens.shift();
   } else {
     // so x
 
@@ -366,15 +366,15 @@ function handleSo(keys)
  * Produces:
  * // text
  */
-function handleShh(keys)
+function handleShh(tokens)
 {
-  expectToken('shh', keys);
+  expectToken('shh', tokens);
 
   // consume: shh
-  keys.shift();
+  tokens.shift();
 
   var statement = '// ';
-  statement += joinTokens(keys);
+  statement += joinTokens(tokens);
   statement += '\n';
 
   return statement;
@@ -386,17 +386,17 @@ function handleShh(keys)
  *
  * Produces the start of a multi-line comment "/*"
  */
- function handleQuiet(keys)
+ function handleQuiet(tokens)
  {
-   expectToken('quiet', keys);
+   expectToken('quiet', tokens);
 
    // consume: quiet
-   keys.shift();
+   tokens.shift();
 
    multiComment = true;
 
    var statement = '/*';
-   statement += joinTokens(keys);
+   statement += joinTokens(tokens);
    statement += '\n';
 
    return statement;
@@ -408,9 +408,9 @@ function handleShh(keys)
  *
  * Produces the end of a multiline comment "*\/"
  */
-function handleLoud(keys)
+function handleLoud(tokens)
 {
-  expectToken('loud', keys);
+  expectToken('loud', tokens);
 
   if(!multiComment)
   {
@@ -418,12 +418,12 @@ function handleLoud(keys)
   }
 
   // consume: loud
-  keys.shift();
+  tokens.shift();
 
   multiComment = false;
 
   var statement = '*/';
-  statement += joinTokens(keys);
+  statement += joinTokens(tokens);
   statement += '\n';
 
   return statement;
@@ -435,23 +435,23 @@ function handleLoud(keys)
  * new x [with args]
  *
  */
-function handleNew(keys)
+function handleNew(tokens)
 {
-  expectToken('new', keys);
+  expectToken('new', tokens);
 
   // consume: new
-  keys.shift();
+  tokens.shift();
 
   var statement = 'new ';
 
-  var object = keys.shift();
+  var object = tokens.shift();
 
   // handle arguments
-  if(keys[0] === 'with' )
+  if(tokens[0] === 'with' )
   {
     // add constructor name
     statement += object;
-    statement += handleWith(keys);
+    statement += handleWith(tokens);
     return statement;
   }
 
@@ -470,15 +470,15 @@ function handleNew(keys)
  * Handles if statements:
  * rly [condition]
  */
-function handleRly(keys)
+function handleRly(tokens)
 {
-  expectToken('rly', keys);
+  expectToken('rly', tokens);
 
   // consume: rly
-  keys.shift();
+  tokens.shift();
 
   var statement = 'if ('
-  statement += controlFlowParser(keys);
+  statement += controlFlowParser(tokens);
   // close condition and open branch
   statement += ') {\n';
   return statement;
@@ -488,15 +488,15 @@ function handleRly(keys)
  * Handles negated if statements:
  * notrly [condition]
  */
-function handleNotrly(keys)
+function handleNotrly(tokens)
 {
-  expectToken('notrly', keys);
+  expectToken('notrly', tokens);
 
   // consume: notrly
-  keys.shift();
+  tokens.shift();
 
   var statement = 'if (!';
-  statement += controlFlowParser(keys);
+  statement += controlFlowParser(tokens);
   // close condition and open branch
   statement += ') {\n';
   return statement;
@@ -507,22 +507,22 @@ function handleNotrly(keys)
  * but [condition]
  * but [rly|notrly] [condition]
  */
-function handleBut(keys)
+function handleBut(tokens)
 {
-  expectToken('but', keys);
+  expectToken('but', tokens);
 
   // consume: but
-  keys.shift();
+  tokens.shift();
 
   var statement = '} else ';
-  if (keys[0] === 'rly' || keys[0] === 'notrly' )
+  if (tokens[0] === 'rly' || tokens[0] === 'notrly' )
   {
-    if(keys[0] === 'rly' )
+    if(tokens[0] === 'rly' )
     {
-      statement += handleRly(keys);
+      statement += handleRly(tokens);
     }
     else {
-      statement += handleNotrly(keys);
+      statement += handleNotrly(tokens);
     }
   }
   else
@@ -540,45 +540,45 @@ function handleBut(keys)
  * Produces:
  * (<args>)
  */
-function handleWith(keys)
+function handleWith(tokens)
 {
-  expectToken('with', keys);
+  expectToken('with', tokens);
   // consume: with
-  keys.shift();
+  tokens.shift();
 
   var statement = '(';
 
-  // if the last key ends with & we are chaining calls
-  var chained = keys[keys.length - 1].slice(-1) === '&';
+  // if the last token ends with & we are chaining calls
+  var chained = tokens[tokens.length - 1].slice(-1) === '&';
 
-  while(keys.length > 0) {
+  while(tokens.length > 0) {
 
-      // look ahead before consuming the key
-      if (keys[0] === 'much') { // lambda functions - thanks @00Davo!
-        var anonStatement = handleLambda(keys);
+      // look ahead before consuming the tokenst
+      if (tokens[0] === 'much') { // lambda functions - thanks @00Davo!
+        var anonStatement = handleLambda(tokens);
         statement += anonStatement;
         return statement;
       }
 
-      var currKey = keys.shift();
-      if (currKey === ',' || currKey === '&') {
+      var currentToken = tokens.shift();
+      if (currentToken === ',' || currentToken === '&') {
         continue;
       }
 
       // clean up name if foo& or foo, to foo
-      if (currKey.substr(-1) === '&' || currKey.substr(-1) === ',') {
-        currKey = currKey.slice(0, -1);
+      if (currentToken.substr(-1) === '&' || currentToken.substr(-1) === ',') {
+        currentToken = currentToken.slice(0, -1);
       }
 
-      statement += currKey;
+      statement += currentToken;
 
       // format a:b into a: b
-      if (currKey.substr(-1) === ':') {
+      if (currentToken.substr(-1) === ':') {
         statement += ' ';
       }
 
       // append , if not last arg or an object literal
-      if (keys.length > 0 && currKey.substr(-1) !== ':') {
+      if (tokens.length > 0 && currentToken.substr(-1) !== ':') {
         statement += ', ';
       }
   }
@@ -612,11 +612,11 @@ function handleWith(keys)
  * Handles inner parsing from control flow statements:
  * rly notrly but much many
  */
-function controlFlowParser(keys)
+function controlFlowParser(tokens)
 {
   var statement = '';
 
-  while(token = keys.shift())
+  while(token = tokens.shift())
   {
     // convert to supported operators (eventually this will just call parse again)
     if(validOperators.hasOwnProperty(token))
@@ -637,24 +637,24 @@ function controlFlowParser(keys)
  * wow [return vals]
  * wow& [return vals]
  */
-function handleWow(keys)
+function handleWow(tokens)
 {
-  expectAnyToken(['wow', 'wow&'], keys);
+  expectAnyToken(['wow', 'wow&'], tokens);
   multiLine = false;
 
-  var chained = keys[0] === 'wow&';
+  var chained = tokens[0] === 'wow&';
 
   // consume: wow/wow&
-  keys.shift();
+  tokens.shift();
 
   var statement = '';
 
-  // add keys if there's a return value
-  if(keys.length > 0)
+  // add tokens if there's a return value
+  if(tokens.length > 0)
   {
     statement += 'return';
-    // ideally this will call parseKeys in the future to support return foo();
-    while(arg = keys.shift())
+    // ideally this will call parsetokens in the future to support return foo();
+    while(arg = tokens.shift())
     {
       statement += ' ' + arg;
     }
@@ -680,15 +680,15 @@ function handleWow(keys)
  * Produces:
  * for(startState; condition; nextState) {
  */
-function handleMuchLoop(keys)
+function handleMuchLoop(tokens)
 {
-  expectToken('much', keys);
+  expectToken('much', tokens);
 
   // consume: much
-  keys.shift();
+  tokens.shift();
 
   var statement = 'for ('
-  statement += controlFlowParser(keys);
+  statement += controlFlowParser(tokens);
   statement += ') {\n';
   return statement;
 }
@@ -700,15 +700,15 @@ function handleMuchLoop(keys)
  * Produces:
  * while(condition) {
  */
-function handleMany(keys)
+function handleMany(tokens)
 {
-  expectToken('many', keys);
+  expectToken('many', tokens);
 
   // consume: many
-  keys.shift();
+  tokens.shift();
 
   var statement = 'while (';
-  statement += controlFlowParser(keys);
+  statement += controlFlowParser(tokens);
   statement += ') {\n';
 
   return statement;
@@ -717,13 +717,13 @@ function handleMany(keys)
 /**
  * Determines appropriate way to invoke a function whether it has args or not
  * @param functionName the name of the function
- * @param keys the set of tokens remaining, if the given keys does not begin with a `with` token a syntax error will be thrown
+ * @param tokens the set of tokens remaining, if the given tokens does not begin with a `with` token a syntax error will be thrown
  * @param allowedSyntax a description of the allowed syntax to invoke the function (in case the syntax is incorrect)
  */
-function functionInvocation(functionName, keys, allowedSyntax)
+function functionInvocation(functionName, tokens, allowedSyntax)
 {
   // no more args
-  if(keys.length < 1)
+  if(tokens.length < 1)
   {
     // if ends with & we are chaining a call
     if(functionName.endsWith('&'))
@@ -736,12 +736,12 @@ function functionInvocation(functionName, keys, allowedSyntax)
   }
 
   // args have to be declared with a `with`
-  if (keys[0] !== 'with')
+  if (tokens[0] !== 'with')
   {
-    throw new Error(`Invalid parse state! Expected: 'with' but got: '${keys[0]}' from chain: [${keys}]. Allowed construct: ${allowedSyntax}`);
+    throw new Error(`Invalid parse state! Expected: 'with' but got: '${tokens[0]}' from chain: [${tokens}]. Allowed construct: ${allowedSyntax}`);
   }
 
-  return functionName + handleWith(keys);
+  return functionName + handleWith(tokens);
 }
 
 /**
@@ -751,12 +751,12 @@ function functionInvocation(functionName, keys, allowedSyntax)
  * Produces:
  *  plz function_name([args])
  */
-function handlePlz(keys)
+function handlePlz(tokens)
 {
-  expectAnyToken(['plz', '.plz'], keys);
+  expectAnyToken(['plz', '.plz'], tokens);
 
   // consume: plz/.plz
-  var invocation = keys.shift();
+  var invocation = tokens.shift();
 
   var statement = '';
   // if it's a .plz we're chaning a call so append the .
@@ -765,7 +765,7 @@ function handlePlz(keys)
     statement += '.';
   }
 
-  var functionName = keys.shift();
+  var functionName = tokens.shift();
 
   // check if function invocation is special name
   if(functionName === 'console.loge')
@@ -773,7 +773,7 @@ function handlePlz(keys)
     functionName = functionName.slice(0, -1);
   }
 
-  statement += functionInvocation(functionName, keys, 'plz|.plz <function_name> [with <args>]');
+  statement += functionInvocation(functionName, tokens, 'plz|.plz <function_name> [with <args>]');
   return statement;
 }
 
@@ -786,27 +786,27 @@ function handlePlz(keys)
  *  object.function_name([args])
  *  .function_name([args])
  */
-function handleDose(keys)
+function handleDose(tokens)
 {
-  if(keys[0] !== 'dose' && keys[1] !== 'dose')
+  if(tokens[0] !== 'dose' && tokens[1] !== 'dose')
   {
-    throw new Error(`Invalid parse state! Expected 'dose' in either 'x dose y' or 'dose y' but got chain: [${keys}]`);
+    throw new Error(`Invalid parse state! Expected 'dose' in either 'x dose y' or 'dose y' but got chain: [${tokens}]`);
   }
 
   var objectName = '';
 
   // if dose is the first token, we're chaining a previous call
-  if(keys[1] === 'dose')
+  if(tokens[1] === 'dose')
   {
     // object dose func
-    objectName = keys.shift();
+    objectName = tokens.shift();
   }
 
   // consume: dose
-  keys.shift();
+  tokens.shift();
 
   var statement = objectName + '.';
-  var functionName = keys.shift();
+  var functionName = tokens.shift();
 
   // check if function invocation is special name
   if(functionName === 'loge' )
@@ -818,7 +818,7 @@ function handleDose(keys)
     }
   }
 
-  statement += functionInvocation(functionName, keys, '[<object>] dose <function_name> [with <args>]');
+  statement += functionInvocation(functionName, tokens, '[<object>] dose <function_name> [with <args>]');
   return statement;
 }
 
@@ -831,21 +831,21 @@ function handleDose(keys)
   *  identifier++ | identifier--
   *  ++identifier | --identifier
   */
-function handleIncrementDecrement(keys)
+function handleIncrementDecrement(tokens)
 {
-  if(!containsIncrementDecrement(keys))
+  if(!containsIncrementDecrement(tokens))
   {
-    throw new Error(`Invalid parse state! Expected an operator from: ${incrementDecrementOps} in either '<identifier> operator' or 'operator <identifer>' but got chain: [${keys}]`);
+    throw new Error(`Invalid parse state! Expected an operator from: ${incrementDecrementOps} in either '<identifier> operator' or 'operator <identifer>' but got chain: [${tokens}]`);
   }
 
   // prefix
-  if(unaryOps.hasOwnProperty(keys[0]))
+  if(unaryOps.hasOwnProperty(tokens[0]))
   {
-    return unaryOps[keys.shift()] + keys.shift()
+    return unaryOps[tokens.shift()] + tokens.shift()
   }
 
   // postfix
-  return keys.shift() + unaryOps[keys.shift()]
+  return tokens.shift() + unaryOps[tokens.shift()]
 }
 
 var replacements = {};
@@ -854,120 +854,120 @@ replacements['windoge']='window'
 
 module.exports = function parse (line) {
 
-    var keys = line.match(/'[^']+'|\S+/g);
+    var tokens = line.match(/'[^']+'|\S+/g);
     var statement = '';
 
-    if (keys === null) return line + '\n';
+    if (tokens === null) return line + '\n';
 
     // if processing multi-comment
     if(multiComment)
     {
       // consume tokens until we encounter loud
-      if(keys[0] !== 'loud')
+      if(tokens[0] !== 'loud')
       {
         return line + '\n';
       }
       // else must be loud
-      return handleLoud(keys);
+      return handleLoud(tokens);
     }
 
-    // pre-process keys and swap replacements
-    for(i = 0; i < keys.length; i ++)
+    // pre-process tokens and swap replacements
+    for(i = 0; i < tokens.length; i ++)
     {
-      var testKey = keys[i];
+      var testToken = tokens[i];
 
       // if we see a shh, skip since everything should be preserved
-      if(testKey === 'shh')
+      if(testToken === 'shh')
       {
         break;
       }
 
       Object.keys(replacements).forEach(function(key) {
 
-        if(testKey === key)
+        if(testToken === key)
         {
-          keys[i] = replacements[key];
+          tokens[i] = replacements[key];
         }
 
-        if(testKey.startsWith(key+'.'))
+        if(testToken.startsWith(key+'.'))
         {
-          keys[i] = testKey.replace(key+'.', replacements[key]+'.');
+          tokens[i] = testToken.replace(key+'.', replacements[key]+'.');
         }
       });
     }
 
     // not dogescript, such javascript
-    if ( !isDogescriptSource(keys) )
+    if ( !isDogescriptSource(tokens) )
     {
-      return joinTokens(keys) + '\n';
+      return joinTokens(tokens) + '\n';
     }
 
     // trained use strict
-    if (keys[0] === 'trained') {
+    if (tokens[0] === 'trained') {
       // consume: trained
-      keys.shift();
+      tokens.shift();
       return '"use strict";\n';
     }
 
-   // such function
-    if (keys[0] === 'such') {
-        return handleSuch(keys);
+    // such function
+    if (tokens[0] === 'such') {
+        return handleSuch(tokens);
     }
 
-    if ( keys[0] === 'wow' || keys[0] === 'wow&' )
+    if ( tokens[0] === 'wow' || tokens[0] === 'wow&' )
     {
-      return handleWow(keys);
+      return handleWow(tokens);
     }
 
     // plz execute function
-    if(keys[0] === 'plz' || keys[0] === '.plz')
+    if(tokens[0] === 'plz' || tokens[0] === '.plz')
     {
-      return handlePlz(keys);
+      return handlePlz(tokens);
     }
     // obj dose function
-    if(keys[0] === 'dose' || keys[1] === 'dose')
+    if(tokens[0] === 'dose' || tokens[1] === 'dose')
     {
-      return handleDose(keys);
+      return handleDose(tokens);
     }
 
     // very new variable
-    if (keys[0] === 'very') {
+    if (tokens[0] === 'very') {
       // consume: very
-      keys.shift();
+      tokens.shift();
 
-      statement += 'var ' + keys.shift() + ' = ';
+      statement += 'var ' + tokens.shift() + ' = ';
 
       // consume:is/as
-      keys.shift();
+      tokens.shift();
 
-      if (keys[0] === 'new') {
-        statement += handleNew(keys);
+      if (tokens[0] === 'new') {
+        statement += handleNew(tokens);
         return statement;
       }
 
-      if (keys[0] === 'much') {
-        var anonStatement = handleLambda(keys);
+      if (tokens[0] === 'much') {
+        var anonStatement = handleLambda(tokens);
         statement += anonStatement;
         return statement;
       }
 
-      if (keys[0] === 'obj') {
+      if (tokens[0] === 'obj') {
         statement += '{\n';
         multiLine = true;
         return statement;
       }
 
-      if (keys.length > 1) {
-        if (isDogescriptSource(keys)) {
-          statement += parse(joinTokens(keys));
+      if (tokens.length > 1) {
+        if (isDogescriptSource(tokens)) {
+          statement += parse(joinTokens(tokens));
           return statement;
         }
 
-        statement += joinTokens(keys);
+        statement += joinTokens(tokens);
       }
       else
       {
-        statement += keys.shift();
+        statement += tokens.shift();
       }
 
       statement += ';\n';
@@ -975,93 +975,93 @@ module.exports = function parse (line) {
     }
 
     // support any kind of assignment operator
-    if(assignOps.hasOwnProperty(keys[1]))
+    if(assignOps.hasOwnProperty(tokens[1]))
     {
-      statement += keys.shift() + assignOps[keys.shift()];
+      statement += tokens.shift() + assignOps[tokens.shift()];
 
-      if (keys[0] === 'new') {
-        statement += handleNew(keys);
+      if (tokens[0] === 'new') {
+        statement += handleNew(tokens);
         return statement;
       }
 
-      if(keys.length > 1) {
-        // this will eventually call parseKeys
-        statement += parse(joinTokens(keys));
+      if(tokens.length > 1) {
+        // this will eventually call parsetokens
+        statement += parse(joinTokens(tokens));
       }
       else {
-        statement += keys.shift() + ';\n';
+        statement += tokens.shift() + ';\n';
       }
 
       return statement;
     }
 
     // shh comment
-    if (keys[0] === 'shh') {
-      return handleShh(keys);
+    if (tokens[0] === 'shh') {
+      return handleShh(tokens);
     }
 
     // quiet start multi-line comment
-    if (keys[0] === 'quiet') {
-      return handleQuiet(keys);
+    if (tokens[0] === 'quiet') {
+      return handleQuiet(tokens);
     }
 
     // rly if
-    if (keys[0] === 'rly') {
-      return handleRly(keys);
+    if (tokens[0] === 'rly') {
+      return handleRly(tokens);
     }
 
     // ntrly if
-    if (keys[0] === 'notrly')
+    if (tokens[0] === 'notrly')
     {
-      return handleNotrly(keys);
+      return handleNotrly(tokens);
     }
 
     // but else
-    if (keys[0] === 'but') {
-      return handleBut(keys);
+    if (tokens[0] === 'but') {
+      return handleBut(tokens);
     }
 
     // many while
-    if (keys[0] === 'many') {
-      return  handleMany(keys);
+    if (tokens[0] === 'many') {
+      return  handleMany(tokens);
     }
 
     // much for
-    if (keys[0] === 'much') {
-      return handleMuchLoop(keys);
+    if (tokens[0] === 'much') {
+      return handleMuchLoop(tokens);
     }
 
     // so require
-    if (keys[0] === 'so') {
-      return handleSo(keys);
+    if (tokens[0] === 'so') {
+      return handleSo(tokens);
     }
 
     // maybe boolean operator
-    if (keys[0] === 'maybe') {
+    if (tokens[0] === 'maybe') {
         // consume: maybe
-        keys.shift();
+        tokens.shift();
         return '(!!+Math.round(Math.random()))';
     }
 
     // standalone increment/decrement
-    if(containsIncrementDecrement(keys))
+    if(containsIncrementDecrement(tokens))
     {
       // ignore operators that should have been snagged by control flow elements (removed once control flow consumes tokens)
-      if(controlFlowKeys.indexOf(keys[0]) === -1)
+      if(controlFlowTokens.indexOf(tokens[0]) === -1)
       {
-        return handleIncrementDecrement(keys);
+        return handleIncrementDecrement(tokens);
       }
     }
 
-    if(keys[0] === 'woof')
+    if(tokens[0] === 'woof')
     {
-      return handleWoof(keys);
+      return handleWoof(tokens);
     }
 
-    if(keys[0] === 'debooger' || keys[0] === 'pawse')
+    if(tokens[0] === 'debooger' || tokens[0] === 'pawse')
     {
       // consume: debooger/pawse
-      keys.shift();
+      tokens.shift();
       return 'debugger;'
     }
 


### PR DESCRIPTION
Rename `keys` to `tokens` and `key` to `token` where applicable, makes it more parser-ey.