### PR TITLE
introduce parsing context

### DIFF
--- a/lib/parser.js
+++ b/lib/parser.js
@@ -109,10 +109,8 @@ function expectAnyToken(expectedTokens, parseContext)
  * Joins the set of tokens into a string such that joinTokens([a, b]) returns "a b".
  * Consumes all tokens from the given array such that the array will be empty if it is referenced after calling this function.
  */
-function joinTokens(parseContext)
+function joinTokens(tokens)
 {
-  var tokens = parseContext.tokens;
-
   var tokenString = '';
 
   while(token = tokens.shift())
@@ -209,7 +207,7 @@ function parseInfo(parseContext)
 function handleWoof(parseContext)
 {
   expectToken('woof', parseContext);
-  
+
   var tokens = parseContext.tokens;
 
   // consume: woof
@@ -271,9 +269,9 @@ function handleWoof(parseContext)
 function handleSuch(parseContext)
 {
   expectToken('such', parseContext);
-  
+
   var tokens = parseContext.tokens;
-  
+
   // consume: such
   tokens.shift();
 
@@ -309,7 +307,7 @@ function handleSuch(parseContext)
 function handleMuchArgs(parseContext)
 {
   expectToken('much', parseContext);
-  
+
   var tokens = parseContext.tokens;
 
   // consume: much
@@ -351,7 +349,7 @@ function handleLambda(parseContext)
 function handleSo(parseContext)
 {
   expectToken('so', parseContext);
-  
+
   var tokens = parseContext.tokens;
 
   // consume: so
@@ -394,14 +392,14 @@ function handleSo(parseContext)
 function handleShh(parseContext)
 {
   expectToken('shh', parseContext);
-  
+
   var tokens = parseContext.tokens;
 
   // consume: shh
   tokens.shift();
 
   var statement = '// ';
-  statement += joinTokens(parseContext);
+  statement += joinTokens(parseContext.tokens);
   statement += '\n';
 
   return statement;
@@ -416,7 +414,7 @@ function handleShh(parseContext)
  function handleQuiet(parseContext)
  {
   expectToken('quiet', parseContext);
-   
+
   var tokens = parseContext.tokens;
 
    // consume: quiet
@@ -425,7 +423,7 @@ function handleShh(parseContext)
    multiComment = true;
 
    var statement = '/*';
-   statement += joinTokens(parseContext);
+   statement += joinTokens(parseContext.tokens);
    statement += '\n';
 
    return statement;
@@ -440,7 +438,7 @@ function handleShh(parseContext)
 function handleLoud(parseContext)
 {
   expectToken('loud', parseContext);
-  
+
   var tokens = parseContext.tokens;
 
   if(!multiComment)
@@ -454,7 +452,7 @@ function handleLoud(parseContext)
   multiComment = false;
 
   var statement = '*/';
-  statement += joinTokens(parseContext);
+  statement += joinTokens(parseContext.tokens);
   statement += '\n';
 
   return statement;
@@ -469,7 +467,7 @@ function handleLoud(parseContext)
 function handleNew(parseContext)
 {
   expectToken('new', parseContext);
-  
+
   var tokens = parseContext.tokens;
 
   // consume: new
@@ -506,7 +504,7 @@ function handleNew(parseContext)
 function handleRly(parseContext)
 {
   expectToken('rly', parseContext);
-  
+
   var tokens = parseContext.tokens;
 
   // consume: rly
@@ -526,7 +524,7 @@ function handleRly(parseContext)
 function handleNotrly(parseContext)
 {
   expectToken('notrly', parseContext);
-  
+
   var tokens = parseContext.tokens;
 
   // consume: notrly
@@ -547,7 +545,7 @@ function handleNotrly(parseContext)
 function handleBut(parseContext)
 {
   expectToken('but', parseContext);
-  
+
   var tokens = parseContext.tokens;
 
   // consume: but
@@ -582,9 +580,9 @@ function handleBut(parseContext)
 function handleWith(parseContext)
 {
   expectToken('with', parseContext);
-  
+
   var tokens = parseContext.tokens;
-  
+
   // consume: with
   tokens.shift();
 
@@ -684,7 +682,7 @@ function controlFlowParser(parseContext)
 function handleWow(parseContext)
 {
   expectAnyToken(['wow', 'wow&'], parseContext);
-  
+
   var tokens = parseContext.tokens;
   multiLine = false;
 
@@ -729,9 +727,9 @@ function handleWow(parseContext)
 function handleMuchLoop(parseContext)
 {
   expectToken('much', parseContext);
-  
+
   var tokens = parseContext.tokens;
-  
+
   // consume: much
   tokens.shift();
 
@@ -751,9 +749,9 @@ function handleMuchLoop(parseContext)
 function handleMany(parseContext)
 {
   expectToken('many', parseContext);
-  
+
   var tokens = parseContext.tokens;
-  
+
   // consume: many
   tokens.shift();
 
@@ -893,9 +891,9 @@ function handleIncrementDecrement(parseContext)
   {
     throw new Error(`Invalid parse state! Expected an operator from: ${incrementDecrementOps} in either '<identifier> operator' or 'operator <identifer>' but got chain: [${tokens}]`);
   }
-  
+
   var tokens = parseContext.tokens;
-  
+
   // prefix
   if(unaryOps.hasOwnProperty(tokens[0]))
   {
@@ -921,7 +919,7 @@ module.exports = function parse (line) {
       // leave original tokens to throw better syntax errors
       inputTokens: tokens.slice(),
       tokens: tokens
-    }
+    };
 
     var statement = '';
 
@@ -965,7 +963,7 @@ module.exports = function parse (line) {
     // not dogescript, such javascript
     if ( !isDogescriptSource(parseContext) )
     {
-      return joinTokens(parseContext) + '\n';
+      return joinTokens(parseContext.tokens) + '\n';
     }
 
     // trained use strict
@@ -1025,11 +1023,11 @@ module.exports = function parse (line) {
 
       if (tokens.length > 1) {
         if (isDogescriptSource(parseContext)) {
-          statement += parse(joinTokens(parseContext));
+          statement += parse(joinTokens(parseContext.tokens));
           return statement;
         }
 
-        statement += joinTokens(parseContext);
+        statement += joinTokens(parseContext.tokens);
       }
       else
       {
@@ -1052,7 +1050,7 @@ module.exports = function parse (line) {
 
       if(tokens.length > 1) {
         // this will eventually call parsetokens
-        statement += parse(joinTokens(parseContext));
+        statement += parse(joinTokens(parseContext.tokens));
       }
       else {
         statement += tokens.shift() + ';\n';

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -72,19 +72,22 @@ var valid = [
 /**
  * Raises an error if the given tokens do not start with the desired state
  */
-function expectToken(expectedStart, tokens)
+function expectToken(expectedStart, parseContext)
 {
+  var tokens = parseContext.tokens;
   if ( tokens[0] !== expectedStart)
   {
-    throw new Error(`Invalid parse state! Expected: '${expectedStart}' but got: '${tokens[0]}' from chain: [${tokens}]`);
+    throw new Error(`Invalid parse state! Expected: '${expectedStart}' but got: '${tokens[0]}' from chain: [${tokens}]. ${parseInfo(parseContext)}`);
   }
 }
 
 /**
  * Raises an error if the start token does not match any of the expected tokens.
  */
-function expectAnyToken(expectedTokens, tokens)
+function expectAnyToken(expectedTokens, parseContext)
 {
+  var tokens = parseContext.tokens;
+
   var foundToken = false;
   var firstToken = tokens[0];
   for(i = 0; i < expectedTokens.length; i ++)
@@ -98,7 +101,7 @@ function expectAnyToken(expectedTokens, tokens)
 
   if(!foundToken)
   {
-    throw new Error(`Invalid parse state! Expected any of: '${expectedTokens}' but got: '${tokens[0]}' from chain: [${tokens}]`);
+    throw new Error(`Invalid parse state! Expected any of: '${expectedTokens}' but got: '${tokens[0]}' from chain: [${tokens}]. ${parseInfo(parseContext)}`);
   }
 }
 
@@ -106,8 +109,10 @@ function expectAnyToken(expectedTokens, tokens)
  * Joins the set of tokens into a string such that joinTokens([a, b]) returns "a b".
  * Consumes all tokens from the given array such that the array will be empty if it is referenced after calling this function.
  */
-function joinTokens(tokens)
+function joinTokens(parseContext)
 {
+  var tokens = parseContext.tokens;
+
   var tokenString = '';
 
   while(token = tokens.shift())
@@ -122,24 +127,27 @@ function joinTokens(tokens)
   return tokenString;
 }
 
-function containsUnary(tokens)
+function containsUnary(parseContext)
 {
+  var tokens = parseContext.tokens;
   return unaryOps.hasOwnProperty(tokens[0]) || unaryOps.hasOwnProperty(tokens[1]);
 }
 
 /**
  * Determines whether the first or second token is one of [bigify, smallify]
  */
-function containsIncrementDecrement(tokens)
+function containsIncrementDecrement(parseContext)
 {
+  var tokens = parseContext.tokens;
   return incrementDecrementOps.indexOf(tokens[0]) !== -1 || incrementDecrementOps.indexOf(tokens[1]) !== -1;
 }
 
 /**
  * Determines if the parsed tokens should be treated as dogescript source or not.
  */
-function isDogescriptSource(tokens)
+function isDogescriptSource(parseContext)
 {
+  var tokens = parseContext.tokens;
 
   // starts the statement with a valid token
   if (valid.indexOf(tokens[0]) !== -1)
@@ -154,7 +162,7 @@ function isDogescriptSource(tokens)
   }
 
   // applying a unary operator
-  if ( containsUnary(tokens) )
+  if ( containsUnary(parseContext) )
   {
     return true;
   }
@@ -182,6 +190,14 @@ function isDogescriptSource(tokens)
 }
 
 /**
+ * Creates a formatted message that displays the token set that was parsed and the input.
+ */
+function parseInfo(parseContext)
+{
+  return `Parsed tokens [${parseContext.inputTokens}] from input "${parseContext.input}"`;
+}
+
+/**
  * Handles the woof construct:
  *  woof <alias> be <export>
  *  woof <export>
@@ -190,9 +206,11 @@ function isDogescriptSource(tokens)
  *  module.exports.alias = export
  *  module.exports = export
  */
-function handleWoof(tokens)
+function handleWoof(parseContext)
 {
-  expectToken('woof', tokens);
+  expectToken('woof', parseContext);
+  
+  var tokens = parseContext.tokens;
 
   // consume: woof
   tokens.shift();
@@ -224,7 +242,7 @@ function handleWoof(tokens)
   // module.exports = function x(a,b) {}
   if ( assignmentValue === 'such' )
   {
-    var functionStatement = handleSuch(tokens);
+    var functionStatement = handleSuch(parseContext);
     statement += functionStatement;
     // the closing wow will be in a new line
     return statement;
@@ -233,14 +251,14 @@ function handleWoof(tokens)
   // module.exports = function (a,b) {}
   if ( assignmentValue === 'much')
   {
-    var anonStatement = handleLambda(tokens);
+    var anonStatement = handleLambda(parseContext);
     statement += anonStatement;
     // the closing wow will be in a new line
     return statement;
   }
 
   // TODO support other expressions
-  throw new Error(`Invalid parse state! Expected a value but got: '${tokens[0]}' from chain: [${tokens}]. Allowed construct 'woof [<name> be] <value | <SUCH> | <MUCH> >'`);
+  throw new Error(`Invalid parse state! Expected a value but got: '${tokens[0]}' from chain: [${tokens}]. Allowed construct 'woof [<name> be] <value | <SUCH> | <MUCH> >'. ${parseInfo(parseContext)}`);
 }
 
 /**
@@ -250,9 +268,12 @@ function handleWoof(tokens)
  * Produces:
  *  function <function_name> ([args]) {
  */
-function handleSuch(tokens)
+function handleSuch(parseContext)
 {
-  expectToken('such', tokens);
+  expectToken('such', parseContext);
+  
+  var tokens = parseContext.tokens;
+  
   // consume: such
   tokens.shift();
 
@@ -268,10 +289,10 @@ function handleSuch(tokens)
   // args have to be declared with much
   if (tokens[0] !== 'much')
   {
-    throw new Error(`Invalid parse state! Expected: 'much' but got: '${tokens[0]}' from chain: [${tokens}]. Allowed construct 'such <function_name> [much <args>]'`);
+    throw new Error(`Invalid parse state! Expected: 'much' but got: '${tokens[0]}' from chain: [${tokens}]. Allowed construct 'such <function_name> [much <args>]'. ${parseInfo(parseContext)}`);
   }
 
-  statement += handleMuchArgs(tokens);
+  statement += handleMuchArgs(parseContext);
   return statement;
 }
 
@@ -285,9 +306,11 @@ function handleSuch(tokens)
  * Assuming that the function_name was encountered before this should ultimately produce:
  *  function([args]) {
  */
-function handleMuchArgs(tokens)
+function handleMuchArgs(parseContext)
 {
-  expectToken('much', tokens);
+  expectToken('much', parseContext);
+  
+  var tokens = parseContext.tokens;
 
   // consume: much
   tokens.shift();
@@ -313,9 +336,9 @@ function handleMuchArgs(tokens)
  * Produces:
  *  function (args) {
  */
-function handleLambda(tokens)
+function handleLambda(parseContext)
 {
-  return 'function' + handleMuchArgs(tokens);
+  return 'function' + handleMuchArgs(parseContext);
 }
 
 /**
@@ -325,9 +348,11 @@ function handleLambda(tokens)
  * Produces:
  *  var name = require('module');
  */
-function handleSo(tokens)
+function handleSo(parseContext)
 {
-  expectToken('so', tokens);
+  expectToken('so', parseContext);
+  
+  var tokens = parseContext.tokens;
 
   // consume: so
   tokens.shift();
@@ -339,7 +364,7 @@ function handleSo(tokens)
 
   // check if it's a named import or not
   if(tokens.length > 0) {
-    expectToken('as', tokens);
+    expectToken('as', parseContext);
     // consume: as
     tokens.shift();
     modName = tokens.shift();
@@ -366,15 +391,17 @@ function handleSo(tokens)
  * Produces:
  * // text
  */
-function handleShh(tokens)
+function handleShh(parseContext)
 {
-  expectToken('shh', tokens);
+  expectToken('shh', parseContext);
+  
+  var tokens = parseContext.tokens;
 
   // consume: shh
   tokens.shift();
 
   var statement = '// ';
-  statement += joinTokens(tokens);
+  statement += joinTokens(parseContext);
   statement += '\n';
 
   return statement;
@@ -386,9 +413,11 @@ function handleShh(tokens)
  *
  * Produces the start of a multi-line comment "/*"
  */
- function handleQuiet(tokens)
+ function handleQuiet(parseContext)
  {
-   expectToken('quiet', tokens);
+  expectToken('quiet', parseContext);
+   
+  var tokens = parseContext.tokens;
 
    // consume: quiet
    tokens.shift();
@@ -396,7 +425,7 @@ function handleShh(tokens)
    multiComment = true;
 
    var statement = '/*';
-   statement += joinTokens(tokens);
+   statement += joinTokens(parseContext);
    statement += '\n';
 
    return statement;
@@ -408,9 +437,11 @@ function handleShh(tokens)
  *
  * Produces the end of a multiline comment "*\/"
  */
-function handleLoud(tokens)
+function handleLoud(parseContext)
 {
-  expectToken('loud', tokens);
+  expectToken('loud', parseContext);
+  
+  var tokens = parseContext.tokens;
 
   if(!multiComment)
   {
@@ -423,7 +454,7 @@ function handleLoud(tokens)
   multiComment = false;
 
   var statement = '*/';
-  statement += joinTokens(tokens);
+  statement += joinTokens(parseContext);
   statement += '\n';
 
   return statement;
@@ -435,9 +466,11 @@ function handleLoud(tokens)
  * new x [with args]
  *
  */
-function handleNew(tokens)
+function handleNew(parseContext)
 {
-  expectToken('new', tokens);
+  expectToken('new', parseContext);
+  
+  var tokens = parseContext.tokens;
 
   // consume: new
   tokens.shift();
@@ -451,7 +484,7 @@ function handleNew(tokens)
   {
     // add constructor name
     statement += object;
-    statement += handleWith(tokens);
+    statement += handleWith(parseContext);
     return statement;
   }
 
@@ -470,15 +503,17 @@ function handleNew(tokens)
  * Handles if statements:
  * rly [condition]
  */
-function handleRly(tokens)
+function handleRly(parseContext)
 {
-  expectToken('rly', tokens);
+  expectToken('rly', parseContext);
+  
+  var tokens = parseContext.tokens;
 
   // consume: rly
   tokens.shift();
 
   var statement = 'if ('
-  statement += controlFlowParser(tokens);
+  statement += controlFlowParser(parseContext);
   // close condition and open branch
   statement += ') {\n';
   return statement;
@@ -488,15 +523,17 @@ function handleRly(tokens)
  * Handles negated if statements:
  * notrly [condition]
  */
-function handleNotrly(tokens)
+function handleNotrly(parseContext)
 {
-  expectToken('notrly', tokens);
+  expectToken('notrly', parseContext);
+  
+  var tokens = parseContext.tokens;
 
   // consume: notrly
   tokens.shift();
 
   var statement = 'if (!';
-  statement += controlFlowParser(tokens);
+  statement += controlFlowParser(parseContext);
   // close condition and open branch
   statement += ') {\n';
   return statement;
@@ -507,9 +544,11 @@ function handleNotrly(tokens)
  * but [condition]
  * but [rly|notrly] [condition]
  */
-function handleBut(tokens)
+function handleBut(parseContext)
 {
-  expectToken('but', tokens);
+  expectToken('but', parseContext);
+  
+  var tokens = parseContext.tokens;
 
   // consume: but
   tokens.shift();
@@ -519,10 +558,10 @@ function handleBut(tokens)
   {
     if(tokens[0] === 'rly' )
     {
-      statement += handleRly(tokens);
+      statement += handleRly(parseContext);
     }
     else {
-      statement += handleNotrly(tokens);
+      statement += handleNotrly(parseContext);
     }
   }
   else
@@ -540,9 +579,12 @@ function handleBut(tokens)
  * Produces:
  * (<args>)
  */
-function handleWith(tokens)
+function handleWith(parseContext)
 {
-  expectToken('with', tokens);
+  expectToken('with', parseContext);
+  
+  var tokens = parseContext.tokens;
+  
   // consume: with
   tokens.shift();
 
@@ -555,7 +597,7 @@ function handleWith(tokens)
 
       // look ahead before consuming the tokenst
       if (tokens[0] === 'much') { // lambda functions - thanks @00Davo!
-        var anonStatement = handleLambda(tokens);
+        var anonStatement = handleLambda(parseContext);
         statement += anonStatement;
         return statement;
       }
@@ -612,8 +654,10 @@ function handleWith(tokens)
  * Handles inner parsing from control flow statements:
  * rly notrly but much many
  */
-function controlFlowParser(tokens)
+function controlFlowParser(parseContext)
 {
+  var tokens = parseContext.tokens;
+
   var statement = '';
 
   while(token = tokens.shift())
@@ -637,9 +681,11 @@ function controlFlowParser(tokens)
  * wow [return vals]
  * wow& [return vals]
  */
-function handleWow(tokens)
+function handleWow(parseContext)
 {
-  expectAnyToken(['wow', 'wow&'], tokens);
+  expectAnyToken(['wow', 'wow&'], parseContext);
+  
+  var tokens = parseContext.tokens;
   multiLine = false;
 
   var chained = tokens[0] === 'wow&';
@@ -680,15 +726,17 @@ function handleWow(tokens)
  * Produces:
  * for(startState; condition; nextState) {
  */
-function handleMuchLoop(tokens)
+function handleMuchLoop(parseContext)
 {
-  expectToken('much', tokens);
-
+  expectToken('much', parseContext);
+  
+  var tokens = parseContext.tokens;
+  
   // consume: much
   tokens.shift();
 
   var statement = 'for ('
-  statement += controlFlowParser(tokens);
+  statement += controlFlowParser(parseContext);
   statement += ') {\n';
   return statement;
 }
@@ -700,15 +748,17 @@ function handleMuchLoop(tokens)
  * Produces:
  * while(condition) {
  */
-function handleMany(tokens)
+function handleMany(parseContext)
 {
-  expectToken('many', tokens);
-
+  expectToken('many', parseContext);
+  
+  var tokens = parseContext.tokens;
+  
   // consume: many
   tokens.shift();
 
   var statement = 'while (';
-  statement += controlFlowParser(tokens);
+  statement += controlFlowParser(parseContext);
   statement += ') {\n';
 
   return statement;
@@ -720,8 +770,10 @@ function handleMany(tokens)
  * @param tokens the set of tokens remaining, if the given tokens does not begin with a `with` token a syntax error will be thrown
  * @param allowedSyntax a description of the allowed syntax to invoke the function (in case the syntax is incorrect)
  */
-function functionInvocation(functionName, tokens, allowedSyntax)
+function functionInvocation(functionName, parseContext, allowedSyntax)
 {
+  var tokens = parseContext.tokens;
+
   // no more args
   if(tokens.length < 1)
   {
@@ -741,7 +793,7 @@ function functionInvocation(functionName, tokens, allowedSyntax)
     throw new Error(`Invalid parse state! Expected: 'with' but got: '${tokens[0]}' from chain: [${tokens}]. Allowed construct: ${allowedSyntax}`);
   }
 
-  return functionName + handleWith(tokens);
+  return functionName + handleWith(parseContext);
 }
 
 /**
@@ -751,9 +803,11 @@ function functionInvocation(functionName, tokens, allowedSyntax)
  * Produces:
  *  plz function_name([args])
  */
-function handlePlz(tokens)
+function handlePlz(parseContext)
 {
-  expectAnyToken(['plz', '.plz'], tokens);
+  expectAnyToken(['plz', '.plz'], parseContext);
+
+  var tokens = parseContext.tokens;
 
   // consume: plz/.plz
   var invocation = tokens.shift();
@@ -773,7 +827,7 @@ function handlePlz(tokens)
     functionName = functionName.slice(0, -1);
   }
 
-  statement += functionInvocation(functionName, tokens, 'plz|.plz <function_name> [with <args>]');
+  statement += functionInvocation(functionName, parseContext, 'plz|.plz <function_name> [with <args>]');
   return statement;
 }
 
@@ -786,8 +840,10 @@ function handlePlz(tokens)
  *  object.function_name([args])
  *  .function_name([args])
  */
-function handleDose(tokens)
+function handleDose(parseContext)
 {
+  var tokens = parseContext.tokens;
+
   if(tokens[0] !== 'dose' && tokens[1] !== 'dose')
   {
     throw new Error(`Invalid parse state! Expected 'dose' in either 'x dose y' or 'dose y' but got chain: [${tokens}]`);
@@ -818,7 +874,7 @@ function handleDose(tokens)
     }
   }
 
-  statement += functionInvocation(functionName, tokens, '[<object>] dose <function_name> [with <args>]');
+  statement += functionInvocation(functionName, parseContext, '[<object>] dose <function_name> [with <args>]');
   return statement;
 }
 
@@ -831,13 +887,15 @@ function handleDose(tokens)
   *  identifier++ | identifier--
   *  ++identifier | --identifier
   */
-function handleIncrementDecrement(tokens)
+function handleIncrementDecrement(parseContext)
 {
-  if(!containsIncrementDecrement(tokens))
+  if(!containsIncrementDecrement(parseContext))
   {
     throw new Error(`Invalid parse state! Expected an operator from: ${incrementDecrementOps} in either '<identifier> operator' or 'operator <identifer>' but got chain: [${tokens}]`);
   }
-
+  
+  var tokens = parseContext.tokens;
+  
   // prefix
   if(unaryOps.hasOwnProperty(tokens[0]))
   {
@@ -855,9 +913,17 @@ replacements['windoge']='window'
 module.exports = function parse (line) {
 
     var tokens = line.match(/'[^']+'|\S+/g);
-    var statement = '';
 
     if (tokens === null) return line + '\n';
+
+    var parseContext = {
+      input: line,
+      // leave original tokens to throw better syntax errors
+      inputTokens: tokens.slice(),
+      tokens: tokens
+    }
+
+    var statement = '';
 
     // if processing multi-comment
     if(multiComment)
@@ -868,7 +934,7 @@ module.exports = function parse (line) {
         return line + '\n';
       }
       // else must be loud
-      return handleLoud(tokens);
+      return handleLoud(parseContext);
     }
 
     // pre-process tokens and swap replacements
@@ -897,9 +963,9 @@ module.exports = function parse (line) {
     }
 
     // not dogescript, such javascript
-    if ( !isDogescriptSource(tokens) )
+    if ( !isDogescriptSource(parseContext) )
     {
-      return joinTokens(tokens) + '\n';
+      return joinTokens(parseContext) + '\n';
     }
 
     // trained use strict
@@ -911,23 +977,23 @@ module.exports = function parse (line) {
 
     // such function
     if (tokens[0] === 'such') {
-        return handleSuch(tokens);
+        return handleSuch(parseContext);
     }
 
     if ( tokens[0] === 'wow' || tokens[0] === 'wow&' )
     {
-      return handleWow(tokens);
+      return handleWow(parseContext);
     }
 
     // plz execute function
     if(tokens[0] === 'plz' || tokens[0] === '.plz')
     {
-      return handlePlz(tokens);
+      return handlePlz(parseContext);
     }
     // obj dose function
     if(tokens[0] === 'dose' || tokens[1] === 'dose')
     {
-      return handleDose(tokens);
+      return handleDose(parseContext);
     }
 
     // very new variable
@@ -941,12 +1007,12 @@ module.exports = function parse (line) {
       tokens.shift();
 
       if (tokens[0] === 'new') {
-        statement += handleNew(tokens);
+        statement += handleNew(parseContext);
         return statement;
       }
 
       if (tokens[0] === 'much') {
-        var anonStatement = handleLambda(tokens);
+        var anonStatement = handleLambda(parseContext);
         statement += anonStatement;
         return statement;
       }
@@ -958,12 +1024,12 @@ module.exports = function parse (line) {
       }
 
       if (tokens.length > 1) {
-        if (isDogescriptSource(tokens)) {
-          statement += parse(joinTokens(tokens));
+        if (isDogescriptSource(parseContext)) {
+          statement += parse(joinTokens(parseContext));
           return statement;
         }
 
-        statement += joinTokens(tokens);
+        statement += joinTokens(parseContext);
       }
       else
       {
@@ -980,13 +1046,13 @@ module.exports = function parse (line) {
       statement += tokens.shift() + assignOps[tokens.shift()];
 
       if (tokens[0] === 'new') {
-        statement += handleNew(tokens);
+        statement += handleNew(parseContext);
         return statement;
       }
 
       if(tokens.length > 1) {
         // this will eventually call parsetokens
-        statement += parse(joinTokens(tokens));
+        statement += parse(joinTokens(parseContext));
       }
       else {
         statement += tokens.shift() + ';\n';
@@ -997,43 +1063,43 @@ module.exports = function parse (line) {
 
     // shh comment
     if (tokens[0] === 'shh') {
-      return handleShh(tokens);
+      return handleShh(parseContext);
     }
 
     // quiet start multi-line comment
     if (tokens[0] === 'quiet') {
-      return handleQuiet(tokens);
+      return handleQuiet(parseContext);
     }
 
     // rly if
     if (tokens[0] === 'rly') {
-      return handleRly(tokens);
+      return handleRly(parseContext);
     }
 
     // ntrly if
     if (tokens[0] === 'notrly')
     {
-      return handleNotrly(tokens);
+      return handleNotrly(parseContext);
     }
 
     // but else
     if (tokens[0] === 'but') {
-      return handleBut(tokens);
+      return handleBut(parseContext);
     }
 
     // many while
     if (tokens[0] === 'many') {
-      return  handleMany(tokens);
+      return  handleMany(parseContext);
     }
 
     // much for
     if (tokens[0] === 'much') {
-      return handleMuchLoop(tokens);
+      return handleMuchLoop(parseContext);
     }
 
     // so require
     if (tokens[0] === 'so') {
-      return handleSo(tokens);
+      return handleSo(parseContext);
     }
 
     // maybe boolean operator
@@ -1044,18 +1110,18 @@ module.exports = function parse (line) {
     }
 
     // standalone increment/decrement
-    if(containsIncrementDecrement(tokens))
+    if(containsIncrementDecrement(parseContext))
     {
       // ignore operators that should have been snagged by control flow elements (removed once control flow consumes tokens)
       if(controlFlowTokens.indexOf(tokens[0]) === -1)
       {
-        return handleIncrementDecrement(tokens);
+        return handleIncrementDecrement(parseContext);
       }
     }
 
     if(tokens[0] === 'woof')
     {
-      return handleWoof(tokens);
+      return handleWoof(parseContext);
     }
 
     if(tokens[0] === 'debooger' || tokens[0] === 'pawse')


### PR DESCRIPTION
Introduces a parsing context that will keep state of what we got, what we parsed and the tokens we currently have.

From the exported `parse` function, we need a reference to the `line` and the `tokens`. Encapsulating both in an object we pass around will let us extract most of the logic in `parse` into functions that can be called from our other functions. 

Part of the way we recursively parse is by rebuilding a new input and then calling `parse(line)` .

Once this is merged i'll move most of the logic in parse out to a different function.