### PR TITLE
remove reliance on parse

### DIFF
--- a/lib/parser.js
+++ b/lib/parser.js
@@ -904,6 +904,201 @@ function handleIncrementDecrement(parseContext)
   return tokens.shift() + unaryOps[tokens.shift()]
 }
 
+function parseStatement(parseContext) {
+
+  var tokens = parseContext.tokens;
+  var statement = '';
+
+  // if processing multi-comment
+  if(multiComment)
+  {
+    // consume tokens until we encounter loud
+    if(tokens[0] !== 'loud')
+    {
+      return parseContext.input + '\n';
+    }
+    // else must be loud
+    return handleLoud(parseContext);
+  }
+
+  // not dogescript, such javascript
+  if ( !isDogescriptSource(parseContext) )
+  {
+    return joinTokens(tokens) + '\n';
+  }
+
+  // trained use strict
+  if (tokens[0] === 'trained') {
+    // consume: trained
+    tokens.shift();
+    return '"use strict";\n';
+  }
+
+  // such function
+  if (tokens[0] === 'such') {
+      return handleSuch(parseContext);
+  }
+
+  if ( tokens[0] === 'wow' || tokens[0] === 'wow&' )
+  {
+    return handleWow(parseContext);
+  }
+
+  // plz execute function
+  if(tokens[0] === 'plz' || tokens[0] === '.plz')
+  {
+    return handlePlz(parseContext);
+  }
+  // obj dose function
+  if(tokens[0] === 'dose' || tokens[1] === 'dose')
+  {
+    return handleDose(parseContext);
+  }
+
+  // very new variable
+  if (tokens[0] === 'very') {
+    // consume: very
+    tokens.shift();
+
+    statement += 'var ' + tokens.shift() + ' = ';
+
+    // consume:is/as
+    tokens.shift();
+
+    if (tokens[0] === 'new') {
+      statement += handleNew(parseContext);
+      return statement;
+    }
+
+    if (tokens[0] === 'much') {
+      var anonStatement = handleLambda(parseContext);
+      statement += anonStatement;
+      return statement;
+    }
+
+    if (tokens[0] === 'obj') {
+      statement += '{\n';
+      multiLine = true;
+      return statement;
+    }
+
+    if (tokens.length > 1) {
+      statement += parseStatement(parseContext);
+    
+      // don't let the fall through append an extra ';' if the statement can be considered already closed
+      if(statement.trim().endsWith(";"))
+      {
+        return statement;
+      }
+
+      // when we multi chain on the next line we can't append a ';'
+      if(statement.trim().endsWith(")"))
+      {
+        return statement;
+      }
+    }
+    else
+    {
+      statement += tokens.shift();
+    }
+
+    statement += ';\n';
+    return statement;
+  }
+
+  // support any kind of assignment operator
+  if(assignOps.hasOwnProperty(tokens[1]))
+  {
+    statement += tokens.shift() + assignOps[tokens.shift()];
+
+    if (tokens[0] === 'new') {
+      statement += handleNew(parseContext);
+      return statement;
+    }
+
+    if(tokens.length > 1) {
+      statement += parseStatement(parseContext);
+    }
+    else {
+      statement += tokens.shift() + ';\n';
+    }
+
+    return statement;
+  }
+
+  // shh comment
+  if (tokens[0] === 'shh') {
+    return handleShh(parseContext);
+  }
+
+  // quiet start multi-line comment
+  if (tokens[0] === 'quiet') {
+    return handleQuiet(parseContext);
+  }
+
+  // rly if
+  if (tokens[0] === 'rly') {
+    return handleRly(parseContext);
+  }
+
+  // ntrly if
+  if (tokens[0] === 'notrly')
+  {
+    return handleNotrly(parseContext);
+  }
+
+  // but else
+  if (tokens[0] === 'but') {
+    return handleBut(parseContext);
+  }
+
+  // many while
+  if (tokens[0] === 'many') {
+    return  handleMany(parseContext);
+  }
+
+  // much for
+  if (tokens[0] === 'much') {
+    return handleMuchLoop(parseContext);
+  }
+
+  // so require
+  if (tokens[0] === 'so') {
+    return handleSo(parseContext);
+  }
+
+  // maybe boolean operator
+  if (tokens[0] === 'maybe') {
+      // consume: maybe
+      tokens.shift();
+      return '(!!+Math.round(Math.random()))';
+  }
+
+  // standalone increment/decrement
+  if(containsIncrementDecrement(parseContext))
+  {
+    // ignore operators that should have been snagged by control flow elements (removed once control flow consumes tokens)
+    if(controlFlowTokens.indexOf(tokens[0]) === -1)
+    {
+      return handleIncrementDecrement(parseContext);
+    }
+  }
+
+  if(tokens[0] === 'woof')
+  {
+    return handleWoof(parseContext);
+  }
+
+  if(tokens[0] === 'debooger' || tokens[0] === 'pawse')
+  {
+    // consume: debooger/pawse
+    tokens.shift();
+    return 'debugger;'
+  }
+
+  return statement;
+}
+
 var replacements = {};
 replacements['dogeument']='document'
 replacements['windoge']='window'
@@ -920,20 +1115,6 @@ module.exports = function parse (line) {
       inputTokens: tokens.slice(),
       tokens: tokens
     };
-
-    var statement = '';
-
-    // if processing multi-comment
-    if(multiComment)
-    {
-      // consume tokens until we encounter loud
-      if(tokens[0] !== 'loud')
-      {
-        return line + '\n';
-      }
-      // else must be loud
-      return handleLoud(parseContext);
-    }
 
     // pre-process tokens and swap replacements
     for(i = 0; i < tokens.length; i ++)
@@ -960,174 +1141,5 @@ module.exports = function parse (line) {
       });
     }
 
-    // not dogescript, such javascript
-    if ( !isDogescriptSource(parseContext) )
-    {
-      return joinTokens(parseContext.tokens) + '\n';
-    }
-
-    // trained use strict
-    if (tokens[0] === 'trained') {
-      // consume: trained
-      tokens.shift();
-      return '"use strict";\n';
-    }
-
-    // such function
-    if (tokens[0] === 'such') {
-        return handleSuch(parseContext);
-    }
-
-    if ( tokens[0] === 'wow' || tokens[0] === 'wow&' )
-    {
-      return handleWow(parseContext);
-    }
-
-    // plz execute function
-    if(tokens[0] === 'plz' || tokens[0] === '.plz')
-    {
-      return handlePlz(parseContext);
-    }
-    // obj dose function
-    if(tokens[0] === 'dose' || tokens[1] === 'dose')
-    {
-      return handleDose(parseContext);
-    }
-
-    // very new variable
-    if (tokens[0] === 'very') {
-      // consume: very
-      tokens.shift();
-
-      statement += 'var ' + tokens.shift() + ' = ';
-
-      // consume:is/as
-      tokens.shift();
-
-      if (tokens[0] === 'new') {
-        statement += handleNew(parseContext);
-        return statement;
-      }
-
-      if (tokens[0] === 'much') {
-        var anonStatement = handleLambda(parseContext);
-        statement += anonStatement;
-        return statement;
-      }
-
-      if (tokens[0] === 'obj') {
-        statement += '{\n';
-        multiLine = true;
-        return statement;
-      }
-
-      if (tokens.length > 1) {
-        if (isDogescriptSource(parseContext)) {
-          statement += parse(joinTokens(parseContext.tokens));
-          return statement;
-        }
-
-        statement += joinTokens(parseContext.tokens);
-      }
-      else
-      {
-        statement += tokens.shift();
-      }
-
-      statement += ';\n';
-      return statement;
-    }
-
-    // support any kind of assignment operator
-    if(assignOps.hasOwnProperty(tokens[1]))
-    {
-      statement += tokens.shift() + assignOps[tokens.shift()];
-
-      if (tokens[0] === 'new') {
-        statement += handleNew(parseContext);
-        return statement;
-      }
-
-      if(tokens.length > 1) {
-        // this will eventually call parsetokens
-        statement += parse(joinTokens(parseContext.tokens));
-      }
-      else {
-        statement += tokens.shift() + ';\n';
-      }
-
-      return statement;
-    }
-
-    // shh comment
-    if (tokens[0] === 'shh') {
-      return handleShh(parseContext);
-    }
-
-    // quiet start multi-line comment
-    if (tokens[0] === 'quiet') {
-      return handleQuiet(parseContext);
-    }
-
-    // rly if
-    if (tokens[0] === 'rly') {
-      return handleRly(parseContext);
-    }
-
-    // ntrly if
-    if (tokens[0] === 'notrly')
-    {
-      return handleNotrly(parseContext);
-    }
-
-    // but else
-    if (tokens[0] === 'but') {
-      return handleBut(parseContext);
-    }
-
-    // many while
-    if (tokens[0] === 'many') {
-      return  handleMany(parseContext);
-    }
-
-    // much for
-    if (tokens[0] === 'much') {
-      return handleMuchLoop(parseContext);
-    }
-
-    // so require
-    if (tokens[0] === 'so') {
-      return handleSo(parseContext);
-    }
-
-    // maybe boolean operator
-    if (tokens[0] === 'maybe') {
-        // consume: maybe
-        tokens.shift();
-        return '(!!+Math.round(Math.random()))';
-    }
-
-    // standalone increment/decrement
-    if(containsIncrementDecrement(parseContext))
-    {
-      // ignore operators that should have been snagged by control flow elements (removed once control flow consumes tokens)
-      if(controlFlowTokens.indexOf(tokens[0]) === -1)
-      {
-        return handleIncrementDecrement(parseContext);
-      }
-    }
-
-    if(tokens[0] === 'woof')
-    {
-      return handleWoof(parseContext);
-    }
-
-    if(tokens[0] === 'debooger' || tokens[0] === 'pawse')
-    {
-      // consume: debooger/pawse
-      tokens.shift();
-      return 'debugger;'
-    }
-
-    return statement;
+   return parseStatement(parseContext);
 }


### PR DESCRIPTION
* Moved most of the parsing logic to `parseStatement`

References that were checking if something was dogescript and then calling `joinTokens` or `parse` have been removed in favor of just calling `parseStatement`. 