### PR TITLE
make assign ops qualify on first token

### DIFF
--- a/lib/parser.js
+++ b/lib/parser.js
@@ -172,7 +172,7 @@ function isDogescriptSource(parseContext)
   }
 
   // statement applying an assignment operator
-  if ( assignOps.hasOwnProperty(tokens[1]) )
+  if ( tokens.some(isAssignmentOperator) )
   {
     return true;
   }
@@ -272,6 +272,14 @@ function isBinaryOperator(token)
 function isPropertyOperator(token)
 {
   return propertyOperators.hasOwnProperty(token);
+}
+
+/**
+ * Determines whether the token is an assignment token
+ */
+function isAssignmentOperator(token)
+{
+  return assignOps.hasOwnProperty(token);
 }
 
 /**
@@ -1109,10 +1117,10 @@ function parseStatement(parseContext) {
   }
 
   // support any kind of assignment operator
-  if(assignOps.hasOwnProperty(tokens[1]))
+  if(assignOps.hasOwnProperty(tokens[0]))
   {
-    var statement = '';
-    statement += tokens.shift() + assignOps[tokens.shift()];
+    // TODO some control will have to take place for the ambiguity with is
+    var statement = assignOps[tokens.shift()];
 
     if (tokens[0] === 'new') {
       statement += handleNew(parseContext);


### PR DESCRIPTION
Makes assign operators trigger on `tokens[0]` instead of on the second token. Partially sets up ground for #196 (the `is` ambiguity not solved yet)