### PR TITLE
Add explicit return keyword

### DIFF
--- a/LANGUAGE.md
+++ b/LANGUAGE.md
@@ -48,7 +48,7 @@ Should dogescript be ported to other languages, the `js` portion may be changed 
 
 The following tokens are dogescript keywords and may not be used as *Identifiers* in dogescript programs:
 
-&nbsp;**_&nbsp; and &nbsp; as &nbsp; bigger &nbsp; biggerish &nbsp; bigify &nbsp; but &nbsp; debooger &nbsp; dose &nbsp; few &nbsp; giv &nbsp; is &nbsp; levl &nbsp; less &nbsp; lots &nbsp; loud &nbsp; many &nbsp; maybe &nbsp; more &nbsp; much &nbsp; next &nbsp; not &nbsp; notrly &nbsp; or &nbsp; pawse &nbsp; plz &nbsp; quiet &nbsp; rly &nbsp; shh &nbsp; smaller &nbsp; smallerish &nbsp; smallify &nbsp; so &nbsp; such &nbsp; trained &nbsp; very &nbsp; woof &nbsp; wow &nbsp;_**
+&nbsp;**_&nbsp; amaze &nbsp; and &nbsp; as &nbsp; bigger &nbsp; biggerish &nbsp; bigify &nbsp; but &nbsp; debooger &nbsp; dose &nbsp; few &nbsp; giv &nbsp; is &nbsp; levl &nbsp; less &nbsp; lots &nbsp; loud &nbsp; many &nbsp; maybe &nbsp; more &nbsp; much &nbsp; next &nbsp; not &nbsp; notrly &nbsp; or &nbsp; pawse &nbsp; plz &nbsp; quiet &nbsp; rly &nbsp; shh &nbsp; smaller &nbsp; smallerish &nbsp; smallify &nbsp; so &nbsp; such &nbsp; trained &nbsp; very &nbsp; woof &nbsp; wow &nbsp;_**
 
 Additionally, the following symbols should not be used as *Identifiers*:
 
@@ -93,7 +93,11 @@ The following are the supported assignment operators:
 
 ## Blocks
 
-Blocks in dogescript behave the same as with javascript, however all blocks end with `wow`. Functions that return values can use `wow [val]` to return the value.
+Blocks in dogescript behave the same as with javascript, however all blocks end with `wow`. 
+
+Functions that return values can use `wow [val]` or `amaze [val]` to return the value.
+
+### wow
 
 A block without a return would have the following syntax:
 ```dogescript
@@ -127,7 +131,7 @@ var canvas = d3.select('body')
 ```
 
 The `wow&` operator is used to terminate a block that is passed in as an argument to a call, effectively taking the place of `})`:
-```
+```dogescript
 so http
 http dose createServer with much req res
    res dose writeHead with 200 {'Content-Type': 'text/plain'}
@@ -146,6 +150,23 @@ http.createServer(function(req, res) {
     res.end('so hello\nmuch world');
 })
     .listen(8080);
+```
+
+### amaze
+
+The `amaze` keyword can be used to return a value, without closing the block.
+
+```dogescript
+such foo
+amaze 'bar'
+wow
+```
+
+Becomes:
+```javascript
+function foo() {
+  return 'bar';
+}
 ```
 
 ## Functions

--- a/LANGUAGE.md
+++ b/LANGUAGE.md
@@ -191,7 +191,7 @@ test(function (t) {
 });
 ```
 
-### amaze
+#### amaze
 
 The `amaze` keyword can be used to return a value, without closing the block.
 

--- a/LANGUAGE.md
+++ b/LANGUAGE.md
@@ -152,23 +152,6 @@ http.createServer(function(req, res) {
     .listen(8080);
 ```
 
-### amaze
-
-The `amaze` keyword can be used to return a value, without closing the block.
-
-```dogescript
-such foo
-amaze 'bar'
-wow
-```
-
-Becomes:
-```javascript
-function foo() {
-  return 'bar';
-}
-```
-
 ## Functions
 
 ### Declaration
@@ -206,6 +189,23 @@ test(function (t) {
     t.equal(2 + 3, 5);
     t.equal(7 * 8 + 9, 65);
 });
+```
+
+### amaze
+
+The `amaze` keyword can be used to return a value, without closing the block.
+
+```dogescript
+such foo
+amaze 'bar'
+wow
+```
+
+Becomes:
+```javascript
+function foo() {
+  return 'bar';
+}
 ```
 
 ### Calling functions

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -105,7 +105,8 @@ var valid = [
     'obj', // can be handled as top-level token
     'giv',
     'levl',
-    'next'
+    'next',
+    'amaze'
 ];
 
 /**
@@ -1115,6 +1116,36 @@ function handleLevl(parseContext)
   return `[${tokens.shift()}]`;
 }
 
+/**
+ * Handles explicit return:
+ *  amaze <expression>
+ *
+ * Produces:
+ *  return <expression>;
+ */
+function handleAmaze(parseContext) {
+  expectToken('amaze', parseContext);
+
+  // consume: amaze
+  parseContext.tokens.shift();
+
+  return "return " + returnStatements(parseContext);
+}
+
+/**
+ * Appends statements from the parse context into a single line
+ */
+function returnStatements(parseContext)
+{
+  var statement = parseStatements(parseContext);
+  if(shouldCloseStatement(parseContext, statement))
+  {
+    statement += ';\n';
+  }
+
+  return statement;
+}
+
 function parseStatement(parseContext) {
 
   var tokens = parseContext.tokens;
@@ -1304,6 +1335,10 @@ function parseStatement(parseContext) {
 
   if (tokens[0] === 'levl') {
     return handleLevl(parseContext);
+  }
+
+  if (tokens[0] === 'amaze') {
+    return handleAmaze(parseContext);
   }
 
   var statement = tokens.shift();

--- a/test/spec/amaze/function-call/expect.js
+++ b/test/spec/amaze/function-call/expect.js
@@ -1,0 +1,3 @@
+function foo() {
+    return bar();
+}

--- a/test/spec/amaze/function-call/source.djs
+++ b/test/spec/amaze/function-call/source.djs
@@ -1,0 +1,3 @@
+such foo
+  amaze plz bar
+wow

--- a/test/spec/amaze/function-early-return/expect.js
+++ b/test/spec/amaze/function-early-return/expect.js
@@ -1,0 +1,8 @@
+function foo() {
+
+    if (bar === '') {
+        return;
+    }
+
+    baz();
+}

--- a/test/spec/amaze/function-early-return/source.djs
+++ b/test/spec/amaze/function-early-return/source.djs
@@ -1,0 +1,8 @@
+such foo
+
+rly bar is ''
+amaze
+wow
+
+plz baz
+wow

--- a/test/spec/amaze/in-lambda/expect.js
+++ b/test/spec/amaze/in-lambda/expect.js
@@ -1,0 +1,6 @@
+foo(function(n) {
+    if (n < 0) {
+        return 0;
+    }
+    return n;
+})

--- a/test/spec/amaze/in-lambda/source.djs
+++ b/test/spec/amaze/in-lambda/source.djs
@@ -1,0 +1,6 @@
+plz foo with much n
+  rly n smaller 0
+    amaze 0
+  wow
+  amaze n
+wow&

--- a/test/spec/amaze/single-expression/expect.js
+++ b/test/spec/amaze/single-expression/expect.js
@@ -1,0 +1,3 @@
+function add(a, b) {
+    return a + b;
+}

--- a/test/spec/amaze/single-expression/source.djs
+++ b/test/spec/amaze/single-expression/source.djs
@@ -1,0 +1,3 @@
+such add much a b
+  amaze a + b
+wow

--- a/test/spec/amaze/single-value/expect.js
+++ b/test/spec/amaze/single-value/expect.js
@@ -1,0 +1,3 @@
+function foo() {
+    return 'bar';
+}

--- a/test/spec/amaze/single-value/source.djs
+++ b/test/spec/amaze/single-value/source.djs
@@ -1,0 +1,3 @@
+such foo
+  amaze 'bar'
+wow


### PR DESCRIPTION
Adds `amaze` to fix #174 

I'm hoping with this and support for `also` as a `,` we can fix: https://github.com/dogescript/dogescript/issues/115#issuecomment-449425489

The handling of return can also start using the `parseStatement` functions since our current logic for `wow&` just grabs all the tokens, so you can't do `wow plz foo`