### PR TITLE
Downgrade multi-tape to support Node6

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "heroku-client": "^3.0.7",
     "multi-tape": "^1.2.1",
     "tap-dot": "^2.0.0",
+    "tap-yaml": "0.4.0",
     "tape": "^4.10.1",
     "uglify-js": "^3.4.9",
     "walk": "^2.3.14"

--- a/package.json
+++ b/package.json
@@ -37,9 +37,8 @@
     "express": "^4.16.4",
     "glob": "^7.1.3",
     "heroku-client": "^3.0.7",
-    "multi-tape": "^1.2.1",
+    "multi-tape": "1.2.1",
     "tap-dot": "^2.0.0",
-    "tap-yaml": "0.4.0",
     "tape": "^4.10.1",
     "uglify-js": "^3.4.9",
     "walk": "^2.3.14"


### PR DESCRIPTION
Locks down multi-tape to 1.2.1 to resolve issue with a transitive dependency bringing in the spread operator, which isn't supported in Node 6.

However, since the latest LTS are 10 and 12, and the releases seems to point out that Node6 support isn't a thing anymore, would it be better to upgrade our stack to node 10 and 12?