### PR TITLE
extract class handlers

### DIFF
--- a/lib/handlers/classHandlers.js
+++ b/lib/handlers/classHandlers.js
@@ -1,4 +1,86 @@
 var tokenUtils = require('../util/tokenUtils');
+var handlerUtils = require('../util/handlerUtils');
+
+/**
+ * Handles class declarations:
+ *   classy <ClassName>
+ *
+ * Produces:
+ *   class <ClassName> {
+ */
+function handleClass(parseContext) {
+    tokenUtils.expectToken('classy', parseContext);
+  
+    // consume: classy
+    parseContext.tokens.shift();
+  
+    var tokens = parseContext.tokens;
+  
+    /**
+     * We're in a class expression without extension
+     */
+    if(tokens.length < 1)
+    {
+      return "class {\n";
+    }
+  
+    var className = parseContext.tokens.shift();
+    var statement = "class " + className;
+  
+    /**
+     * Check if there's a grows ParentClassName
+     */
+    if(tokens.length > 0)
+    {
+      var nextToken = tokens[0];
+      if(nextToken == 'grows') {
+        statement += " " + handleGrows(parseContext);
+      }
+    }
+  
+    statement += "{\n";
+    return statement;
+  }
+  
+  /**
+   * Handles constructor declarations:
+   * maker <args>
+   *
+   * Produces:
+   *  constructor <args> {
+   */
+  function handleMaker(parseContext) {
+    tokenUtils.expectToken('maker', parseContext);
+  
+    var tokens = parseContext.tokens;
+  
+    // consume: maker
+    tokens.shift();
+  
+    return  'constructor' + handlerUtils.declareArguments(parseContext);
+  }
+  
+  /**
+   * Handles class extension declarations:
+   * grows <ClassName>
+   *
+   * Produces:
+   *  extends <ClassName>
+   */
+  function handleGrows(parseContext) {
+    tokenUtils.expectToken('grows', parseContext);
+  
+    var tokens = parseContext.tokens;
+  
+    // consume: grows
+    tokens.shift();
+  
+    if (tokens.length < 1) {
+      throw new SyntaxError(`Expected ClassName but got nothing. Allowed construct: grows [ClassName]. ${parseInfo(parseContext)}`);
+    }
+  
+    return 'extends ' + tokens.shift();
+  }
 
 /**
  * Handles getter method declarations:
@@ -64,5 +146,5 @@ function handleSit(parseContext) {
 }
 
 module.exports = {
-    handleGit, handleSit
+    handleGit, handleSit , handleClass, handleGrows, handleMaker
 }

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -1072,7 +1072,7 @@ function handleVery(parseContext) {
 
   // the condition check below needs fixing so we can resolve this with just parseStatement
   if (tokens[0] === 'classy') {
-    statement += handleClass(parseContext);
+    statement += classHandlers.handleClass(parseContext);
     return statement;
   }
 
@@ -1131,87 +1131,6 @@ function handleAmaze(parseContext) {
   parseContext.tokens.shift();
 
   return "return " + returnStatements(parseContext);
-}
-
-/**
- * Handles class declarations:
- *   classy <ClassName>
- *
- * Produces:
- *   class <ClassName> {
- */
-function handleClass(parseContext) {
-  expectToken('classy', parseContext);
-
-  // consume: classy
-  parseContext.tokens.shift();
-
-  var tokens = parseContext.tokens;
-
-  /**
-   * We're in a class expression without extension
-   */
-  if(tokens.length < 1)
-  {
-    return "class {\n";
-  }
-
-  var className = parseContext.tokens.shift();
-  var statement = "class " + className;
-
-  /**
-   * Check if there's a grows ParentClassName
-   */
-  if(tokens.length > 0)
-  {
-    var nextToken = tokens[0];
-    if(nextToken == 'grows') {
-      statement += " " + handleGrows(parseContext);
-    }
-  }
-
-  statement += "{\n";
-  return statement;
-}
-
-/**
- * Handles constructor declarations:
- * maker <args>
- *
- * Produces:
- *  constructor <args> {
- */
-function handleMaker(parseContext) {
-  expectToken('maker', parseContext);
-
-  var tokens = parseContext.tokens;
-
-  // consume: maker
-  tokens.shift();
-
-  return  'constructor' + declareArguments(parseContext);
-}
-
-/**
- * Handles class extension declarations:
- * grows <ClassName>
- *
- * Produces:
- *  extends <ClassName>
- */
-function handleGrows(parseContext) {
-  expectToken('grows', parseContext);
-
-  var tokens = parseContext.tokens;
-
-  // consume: grows
-  tokens.shift();
-
-  if (tokens.length < 1) {
-    throw new SyntaxError(`Expected ClassName but got nothing. Allowed construct: grows [ClassName]. ${parseInfo(parseContext)}`);
-  }
-
-  return 'extends ' + tokens.shift();
 }
 
 /**
@@ -1449,11 +1368,11 @@ function parseStatement(parseContext) {
   }
 
   if (tokens[0] === 'classy') {
-    return handleClass(parseContext);
+    return classHandlers.handleClass(parseContext);
   }
 
   if (tokens[0] === 'maker') {
-    return handleMaker(parseContext);
+    return classHandlers.handleMaker(parseContext);
   }
 
   if (tokens[0] === 'git') {

--- a/lib/util/handlerUtils.js
+++ b/lib/util/handlerUtils.js
@@ -1,0 +1,26 @@
+/**
+ * Creates the statement needed when declaring arguments.
+ *
+ * Given: [a, b, c]
+ *
+ * Produces:
+ * ' (a, b, c) { \n'
+ */
+function declareArguments(parseContext) {
+    var tokens = parseContext.tokens;
+  
+    var statement = ' (';
+    let arg;
+    while(arg = tokens.shift())
+    {
+      statement += arg;
+      if(tokens.length > 0)
+      {
+        statement += ', ';
+      }
+    }
+    statement += ') { \n';
+    return statement;
+  }
+
+  module.exports = { declareArguments }


### PR DESCRIPTION
Moves the handlers for class logic into the `classHandlers` (out of parser to make it cleaner)