### PR TITLE
Windows exec

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -77,7 +77,3 @@ npm install
 # and then:
 npm run build # builds dogescript
 ```
-
-## Hacking on Windoges
-
-For optimal experience developing dogescript on windows, we recommend using [WSL](https://docs.microsoft.com/en-us/windows/wsl/install-win10). You can then refer to an already cloned repository by using the `/mnt/c/dogescript` path (or whichever drive you've downloaded dogescript on to). 

--- a/test/transpile.test.js
+++ b/test/transpile.test.js
@@ -19,7 +19,7 @@ function runTest(testDirName)
     /**
      * Execute the binary and capture the stdout
      */
-     exec(`${BINARY_PATH} ${sourcePath}`, { encoding: 'UTF-8' }, (error, stdout, stderr) => {
+     exec(`node ${BINARY_PATH} ${sourcePath}`, { encoding: 'UTF-8' }, (error, stdout, stderr) => {
        expect(error).toEqual(null);
        expect(stderr).toEqual("");
 


### PR DESCRIPTION
make transpile tests require node (previously did not work on windows)