### PR TITLE
Decouple parserState

### DIFF
--- a/lib/parser.js
+++ b/lib/parser.js
@@ -119,6 +119,7 @@ function containsIncrementDecrement(parseContext) {
  */
 function isDogescriptSource(parseContext) {
   var tokens = parseContext.tokens;
+  var state = parseContext.state;
 
   // starts the statement with a valid token
   if (valid.indexOf(tokens[0]) !== -1) {
@@ -141,15 +142,12 @@ function isDogescriptSource(parseContext) {
   }
 
   // ending a multi comment block
-  if (
-    parserState.hasState(StateEnum.MULTILINE_COMMENT) &&
-    tokens[0] === "loud"
-  ) {
+  if (state.hasState(StateEnum.MULTILINE_COMMENT) && tokens[0] === "loud") {
     return true;
   }
 
   // closing a multi-line object creation
-  if (parserState.hasState(StateEnum.OBJECT) && tokens[0] === "wow") {
+  if (state.hasState(StateEnum.OBJECT) && tokens[0] === "wow") {
     return true;
   }
 
@@ -187,6 +185,8 @@ function parseInfo(parseContext) {
  * Determines whether it's appropriate or not to close a statement with a ';'.
  */
 function shouldCloseStatement(parseContext, statement) {
+  var state = parseContext.state;
+
   // there's more to parse
   if (parseContext.tokens.length > 0) {
     return false;
@@ -208,7 +208,7 @@ function shouldCloseStatement(parseContext, statement) {
   }
 
   // if we're in multiline mode, the property:value assignments should not have a ';'
-  return !parserState.hasState(StateEnum.OBJECT);
+  return !state.hasState(StateEnum.OBJECT);
 }
 
 /**
@@ -272,11 +272,12 @@ function handleQuiet(parseContext) {
   tokenUtils.expectToken("quiet", parseContext);
 
   var tokens = parseContext.tokens;
+  var state = parseContext.state;
 
   // consume: quiet
   tokens.shift();
 
-  parserState.pushState(StateEnum.MULTILINE_COMMENT);
+  state.pushState(StateEnum.MULTILINE_COMMENT);
 
   var statement = "/*";
   statement += tokenUtils.joinTokens(parseContext.tokens);
@@ -295,8 +296,9 @@ function handleLoud(parseContext) {
   tokenUtils.expectToken("loud", parseContext);
 
   var tokens = parseContext.tokens;
+  var state = parseContext.state;
 
-  if (!parserState.hasState(StateEnum.MULTILINE_COMMENT)) {
+  if (!state.hasState(StateEnum.MULTILINE_COMMENT)) {
     throw new Error(
       "Unparseable syntax! Encountered: 'loud' without first seeing 'quiet'"
     );
@@ -306,7 +308,7 @@ function handleLoud(parseContext) {
   tokens.shift();
 
   // Remove multicomment state
-  parserState.popState();
+  state.popState();
 
   var statement = "*/";
   statement += tokenUtils.joinTokens(parseContext.tokens);
@@ -323,14 +325,15 @@ function handleRly(parseContext) {
   tokenUtils.expectToken("rly", parseContext);
 
   var tokens = parseContext.tokens;
+  var state = parseContext.state;
 
   // consume: rly
   tokens.shift();
 
   var statement = "if (";
-  parserState.pushState(StateEnum.CONTROL_FLOW);
+  state.pushState(StateEnum.CONTROL_FLOW);
   statement += parseStatements(parseContext);
-  parserState.popState();
+  state.popState();
   // close condition and open branch
   statement += ") {\n";
   return statement;
@@ -344,14 +347,15 @@ function handleNotrly(parseContext) {
   tokenUtils.expectToken("notrly", parseContext);
 
   var tokens = parseContext.tokens;
+  var state = parseContext.state;
 
   // consume: notrly
   tokens.shift();
 
   var statement = "if (!";
-  parserState.pushState(StateEnum.CONTROL_FLOW);
+  state.pushState(StateEnum.CONTROL_FLOW);
   statement += parseStatements(parseContext);
-  parserState.popState();
+  state.popState();
   // close condition and open branch
   statement += ") {\n";
   return statement;
@@ -393,9 +397,11 @@ function handleWow(parseContext) {
   tokenUtils.expectAnyToken(["wow", "wow&"], parseContext);
 
   var tokens = parseContext.tokens;
+  var state = parseContext.state;
+
   // turn off multiline declaration
-  if (parserState.hasState(StateEnum.OBJECT)) {
-    parserState.popState();
+  if (state.hasState(StateEnum.OBJECT)) {
+    state.popState();
   }
 
   var chained = tokens[0] === "wow&";
@@ -438,14 +444,15 @@ function handleMuchLoop(parseContext) {
   tokenUtils.expectToken("much", parseContext);
 
   var tokens = parseContext.tokens;
+  var state = parseContext.state;
 
   // consume: much
   tokens.shift();
 
   var statement = "for (";
-  parserState.pushState(StateEnum.CONTROL_FLOW);
+  state.pushState(StateEnum.CONTROL_FLOW);
   statement += parseStatements(parseContext);
-  parserState.popState();
+  state.popState();
   statement += ") {\n";
   return statement;
 }
@@ -461,14 +468,15 @@ function handleMany(parseContext) {
   tokenUtils.expectToken("many", parseContext);
 
   var tokens = parseContext.tokens;
+  var state = parseContext.state;
 
   // consume: many
   tokens.shift();
 
   var statement = "while (";
-  parserState.pushState(StateEnum.CONTROL_FLOW);
+  state.pushState(StateEnum.CONTROL_FLOW);
   statement += parseStatements(parseContext);
-  parserState.popState();
+  state.popState();
   statement += ") {\n";
 
   return statement;
@@ -512,6 +520,7 @@ function handleVery(parseContext) {
   tokenUtils.expectToken("very", parseContext);
 
   var tokens = parseContext.tokens;
+  var state = parseContext.state;
 
   // consume: very
   tokens.shift();
@@ -536,7 +545,7 @@ function handleVery(parseContext) {
     // consume obj
     tokens.shift();
     statement += "{\n";
-    parserState.pushState(StateEnum.OBJECT);
+    state.pushState(StateEnum.OBJECT);
     return statement;
   }
 
@@ -640,9 +649,10 @@ function returnStatements(parseContext) {
 
 function parseStatement(parseContext) {
   var tokens = parseContext.tokens;
+  var state = parseContext.state;
 
   // if processing multi-comment
-  if (parserState.hasState(StateEnum.MULTILINE_COMMENT)) {
+  if (state.hasState(StateEnum.MULTILINE_COMMENT)) {
     // consume tokens until we encounter loud
     if (tokens[0] !== "loud") {
       // clear out tokens
@@ -689,7 +699,7 @@ function parseStatement(parseContext) {
   }
 
   // only applicable to disambiguate during control flow parsing
-  if (parserState.hasState(StateEnum.CONTROL_FLOW)) {
+  if (state.hasState(StateEnum.CONTROL_FLOW)) {
     // convert to supported operator / otherwise fall thorugh
     // TODO remove operators as they become supported
     if (validOperators.hasOwnProperty(tokens[0])) {
@@ -786,7 +796,7 @@ function parseStatement(parseContext) {
   if (tokens[0] === "obj") {
     // consume obj
     tokens.shift();
-    parserState.pushState(StateEnum.OBJECT);
+    state.pushState(StateEnum.OBJECT);
     return "{\n";
   }
 
@@ -870,7 +880,9 @@ module.exports = function parse(line) {
     input: line,
     // leave original tokens to throw better syntax errors
     inputTokens: tokens.slice(),
-    tokens: tokens
+    tokens: tokens,
+    // pass state so handlers can be extracted out
+    state: parserState
   };
 
   // pre-process tokens and swap replacements


### PR DESCRIPTION
Pass the parser state through the context so handlers that require state don't depend on a variable from the `parser`. 