### PR TITLE
extract comment handlers

### DIFF
--- a/lib/handlers/commentHandlers.js
+++ b/lib/handlers/commentHandlers.js
@@ -1,0 +1,93 @@
+var tokenUtils = require("../util/tokenUtils");
+
+var parserState = require("../parserState");
+const StateEnum = parserState.StateEnum;
+
+/**
+ * Handles the single line comment:
+ * shh [text]
+ *
+ * Produces:
+ * // text
+ */
+function handleShh(parseContext) {
+  tokenUtils.expectToken("shh", parseContext);
+
+  var tokens = parseContext.tokens;
+
+  // consume: shh
+  tokens.shift();
+
+  var statement = "// ";
+
+  // preserve any spacing after 'shh '
+  var input = parseContext.input;
+  var shhLocation = input.indexOf("shh ");
+  var commentText = input.substring(shhLocation + 4);
+  statement += commentText;
+  statement += "\n";
+
+  // consume tokens so we don't reparse
+  parseContext.tokens = [];
+
+  return statement;
+}
+
+/**
+ * Handles the beginning of a multi-line comment:
+ * quiet [comments]
+ *
+ * Produces the start of a multi-line comment "/*"
+ */
+function handleQuiet(parseContext) {
+  tokenUtils.expectToken("quiet", parseContext);
+
+  var tokens = parseContext.tokens;
+
+  // consume: quiet
+  tokens.shift();
+
+  parserState.pushState(StateEnum.MULTILINE_COMMENT);
+
+  var statement = "/*";
+  statement += tokenUtils.joinTokens(parseContext.tokens);
+  statement += "\n";
+
+  return statement;
+}
+
+/**
+ * Handles the end of the multi-line comment:
+ * loud
+ *
+ * Produces the end of a multiline comment "*\/"
+ */
+function handleLoud(parseContext) {
+  tokenUtils.expectToken("loud", parseContext);
+
+  var tokens = parseContext.tokens;
+
+  if (!parserState.hasState(StateEnum.MULTILINE_COMMENT)) {
+    throw new Error(
+      "Unparseable syntax! Encountered: 'loud' without first seeing 'quiet'"
+    );
+  }
+
+  // consume: loud
+  tokens.shift();
+
+  // Remove multicomment state
+  parserState.popState();
+
+  var statement = "*/";
+  statement += tokenUtils.joinTokens(parseContext.tokens);
+  statement += "\n";
+
+  return statement;
+}
+
+module.exports = {
+  handleShh,
+  handleQuiet,
+  handleLoud
+};

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -6,6 +6,7 @@ var classHandlers = require("./handlers/classHandlers");
 var functionHandlers = require("./handlers/functionHandlers");
 var invocationHandlers = require("./handlers/invocationHandlers");
 var moduleHandlers = require("./handlers/moduleHandlers");
+var commentHandlers = require("./handlers/commentHandlers");
 
 var parserState = require("./parserState");
 const StateEnum = parserState.StateEnum;
@@ -230,89 +231,6 @@ function isPropertyOperator(token) {
  */
 function isAssignmentOperator(token) {
   return assignOps.hasOwnProperty(token);
-}
-
-/**
- * Handles the single line comment:
- * shh [text]
- *
- * Produces:
- * // text
- */
-function handleShh(parseContext) {
-  tokenUtils.expectToken("shh", parseContext);
-
-  var tokens = parseContext.tokens;
-
-  // consume: shh
-  tokens.shift();
-
-  var statement = "// ";
-
-  // preserve any spacing after 'shh '
-  var input = parseContext.input;
-  var shhLocation = input.indexOf("shh ");
-  var commentText = input.substring(shhLocation + 4);
-  statement += commentText;
-  statement += "\n";
-
-  // consume tokens so we don't reparse
-  parseContext.tokens = [];
-
-  return statement;
-}
-
-/**
- * Handles the beginning of a multi-line comment:
- * quiet [comments]
- *
- * Produces the start of a multi-line comment "/*"
- */
-function handleQuiet(parseContext) {
-  tokenUtils.expectToken("quiet", parseContext);
-
-  var tokens = parseContext.tokens;
-
-  // consume: quiet
-  tokens.shift();
-
-  parserState.pushState(StateEnum.MULTILINE_COMMENT);
-
-  var statement = "/*";
-  statement += tokenUtils.joinTokens(parseContext.tokens);
-  statement += "\n";
-
-  return statement;
-}
-
-/**
- * Handles the end of the multi-line comment:
- * loud
- *
- * Produces the end of a multiline comment "*\/"
- */
-function handleLoud(parseContext) {
-  tokenUtils.expectToken("loud", parseContext);
-
-  var tokens = parseContext.tokens;
-
-  if (!parserState.hasState(StateEnum.MULTILINE_COMMENT)) {
-    throw new Error(
-      "Unparseable syntax! Encountered: 'loud' without first seeing 'quiet'"
-    );
-  }
-
-  // consume: loud
-  tokens.shift();
-
-  // Remove multicomment state
-  parserState.popState();
-
-  var statement = "*/";
-  statement += tokenUtils.joinTokens(parseContext.tokens);
-  statement += "\n";
-
-  return statement;
 }
 
 /**
@@ -650,7 +568,7 @@ function parseStatement(parseContext) {
       return parseContext.input + "\n";
     }
     // else must be loud
-    return handleLoud(parseContext);
+    return commentHandlers.handleLoud(parseContext);
   }
 
   // not dogescript, such javascript
@@ -717,12 +635,12 @@ function parseStatement(parseContext) {
 
   // shh comment
   if (tokens[0] === "shh") {
-    return handleShh(parseContext);
+    return commentHandlers.handleShh(parseContext);
   }
 
   // quiet start multi-line comment
   if (tokens[0] === "quiet") {
-    return handleQuiet(parseContext);
+    return commentHandlers.handleQuiet(parseContext);
   }
 
   // rly if


### PR DESCRIPTION
Extracts the comment handlers out of the parser. I don't think we'll need #239 since what was happening before doesn't seem to be happening again (with the state not being correct)