### PR TITLE
Create statementHandlers

### DIFF
--- a/lib/handlers/propertyAccessorHandlers.js
+++ b/lib/handlers/propertyAccessorHandlers.js
@@ -1,5 +1,7 @@
 var tokenUtils = require("../util/tokenUtils");
 
+var propertyAccessors = ["giv", "levl"];
+
 /**
  * Handles property accession with an index:
  *  <object> levl <key>
@@ -54,7 +56,15 @@ function handleGiv(parseContext) {
   return ".";
 }
 
+/**
+ * Determines whether the token is a property accessor token
+ */
+function isPropertyAccessor(token) {
+  return propertyAccessors.includes(token);
+}
+
 module.exports = {
   handleLevl,
-  handleGiv
+  handleGiv,
+  isPropertyAccessor
 };

--- a/lib/handlers/statementHandlers.js
+++ b/lib/handlers/statementHandlers.js
@@ -1,0 +1,53 @@
+var tokenUtils = require("../util/tokenUtils");
+
+var parserState = require("../parserState");
+const StateEnum = parserState.StateEnum;
+
+/**
+ * Determines whether it's appropriate or not to close a statement with a ';'.
+ */
+function shouldCloseStatement(parseContext, statement) {
+  // there's more to parse
+  if (parseContext.tokens.length > 0) {
+    return false;
+  }
+
+  // don't append an extra ';' if the statement can be considered already closed
+  if (statement.trim().endsWith(";")) {
+    return false;
+  }
+
+  // when we multi chain call on the next line we can't append a ';'
+  if (statement.trim().endsWith(")")) {
+    return false;
+  }
+
+  // if we're opening a json block we have more statement
+  if (statement.trim().endsWith("{")) {
+    return false;
+  }
+
+  // if we're in multiline mode, the property:value assignments should not have a ';'
+  return !parserState.hasState(StateEnum.OBJECT);
+}
+
+/**
+ * Handles the debugger statement in either:
+ * debooger | pawse
+ *
+ * Produces:
+ *   debugger;
+ */
+function handleDebugger(parseContext) {
+  tokenUtils.expectAnyToken(["debooger", "pawse"], parseContext);
+  var tokens = parseContext.tokens;
+
+  // consume: debooger/pawse
+  tokens.shift();
+  return "debugger;";
+}
+
+module.exports = {
+  shouldCloseStatement,
+  handleDebugger
+};

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -7,8 +7,9 @@ var functionHandlers = require("./handlers/functionHandlers");
 var invocationHandlers = require("./handlers/invocationHandlers");
 var moduleHandlers = require("./handlers/moduleHandlers");
 var commentHandlers = require("./handlers/commentHandlers");
-var propertyAccessorHandlers = require("./handlers/propertyAccessors");
+var propertyAccessorHandlers = require("./handlers/propertyAccessorHandlers");
 var operatorHandlers = require("./handlers/operatorHandlers");
+var statementHandlers = require("./handlers/statementHandlers");
 
 var parserState = require("./parserState");
 const StateEnum = parserState.StateEnum;
@@ -34,11 +35,6 @@ var validOperators = {
   smallify: "--",
   smallified: "--"
 };
-
-// giv can probably be applied as a binary operator since it's a simple transform
-var propertyOperators = ["giv", "levl"];
-
-var controlFlowTokens = ["many", "much", "rly", "but", "notrly"];
 
 var valid = [
   "such",
@@ -120,7 +116,7 @@ function isDogescriptSource(parseContext) {
   }
 
   // something uses a property accessor
-  if (tokens.some(isPropertyOperator)) {
+  if (tokens.some(propertyAccessorHandlers.isPropertyAccessor)) {
     return true;
   }
 
@@ -135,48 +131,6 @@ function isDogescriptSource(parseContext) {
 
   // not valid dogescript
   return false;
-}
-
-/**
- * Creates a formatted message that displays the token set that was parsed and the input.
- */
-function parseInfo(parseContext) {
-  return `Parsed tokens [${parseContext.inputTokens}] from input "${parseContext.input}"`;
-}
-
-/**
- * Determines whether it's appropriate or not to close a statement with a ';'.
- */
-function shouldCloseStatement(parseContext, statement) {
-  // there's more to parse
-  if (parseContext.tokens.length > 0) {
-    return false;
-  }
-
-  // don't append an extra ';' if the statement can be considered already closed
-  if (statement.trim().endsWith(";")) {
-    return false;
-  }
-
-  // when we multi chain call on the next line we can't append a ';'
-  if (statement.trim().endsWith(")")) {
-    return false;
-  }
-
-  // if we're opening a json block we have more statement
-  if (statement.trim().endsWith("{")) {
-    return false;
-  }
-
-  // if we're in multiline mode, the property:value assignments should not have a ';'
-  return !parserState.hasState(StateEnum.OBJECT);
-}
-
-/**
- * Determins whether the token is a property accessor token
- */
-function isPropertyOperator(token) {
-  return propertyOperators.includes(token);
 }
 
 /**
@@ -386,7 +340,7 @@ function handleVery(parseContext) {
   if (tokens.length > 1) {
     statement += parseStatement(parseContext);
 
-    if (!shouldCloseStatement(parseContext, statement)) {
+    if (!statementHandlers.shouldCloseStatement(parseContext, statement)) {
       return statement;
     }
   } else {
@@ -414,34 +368,11 @@ function handleAmaze(parseContext) {
 }
 
 /**
- * Creates the statement needed when declaring arguments.
- *
- * Given: [a, b, c]
- *
- * Produces:
- * ' (a, b, c) { \n'
- */
-function declareArguments(parseContext) {
-  var tokens = parseContext.tokens;
-
-  var statement = " (";
-  let arg;
-  while ((arg = tokens.shift())) {
-    statement += arg;
-    if (tokens.length > 0) {
-      statement += ", ";
-    }
-  }
-  statement += ") { \n";
-  return statement;
-}
-
-/**
  * Appends statements from the parse context into a single line
  */
 function returnStatements(parseContext) {
   var statement = parseStatements(parseContext);
-  if (shouldCloseStatement(parseContext, statement)) {
+  if (statementHandlers.shouldCloseStatement(parseContext, statement)) {
     statement += ";\n";
   }
 
@@ -518,7 +449,7 @@ function parseStatement(parseContext) {
 
     statement += parseStatement(parseContext);
 
-    if (shouldCloseStatement(parseContext, statement)) {
+    if (statementHandlers.shouldCloseStatement(parseContext, statement)) {
       statement += ";\n";
     }
 
@@ -588,9 +519,7 @@ function parseStatement(parseContext) {
   }
 
   if (tokens[0] === "debooger" || tokens[0] === "pawse") {
-    // consume: debooger/pawse
-    tokens.shift();
-    return "debugger;";
+    return statementHandlers.handleDebugger(parseContext);
   }
 
   if (tokens[0] === "obj") {


### PR DESCRIPTION
Cleaned up the parser a bit by extracting a couple of the statement handling functions. The end goal will be that all of the `parseStatement/parseStatements` logic will live in this statementHandlers module (with whatever can be separated out being separated, like the control flow).


Also deleted some unused functions.