### PR TITLE
rename functions

### DIFF
--- a/lib/parser.js
+++ b/lib/parser.js
@@ -147,7 +147,7 @@ function handleRly(parseContext) {
 
   var statement = "if (";
   parserState.pushState(StateEnum.CONTROL_FLOW);
-  statement += parseStatements(parseContext);
+  statement += handleStatements(parseContext);
   parserState.popState();
   // close condition and open branch
   statement += ") {\n";
@@ -168,7 +168,7 @@ function handleNotrly(parseContext) {
 
   var statement = "if (!";
   parserState.pushState(StateEnum.CONTROL_FLOW);
-  statement += parseStatements(parseContext);
+  statement += handleStatements(parseContext);
   parserState.popState();
   // close condition and open branch
   statement += ") {\n";
@@ -262,7 +262,7 @@ function handleMuchLoop(parseContext) {
 
   var statement = "for (";
   parserState.pushState(StateEnum.CONTROL_FLOW);
-  statement += parseStatements(parseContext);
+  statement += handleStatements(parseContext);
   parserState.popState();
   statement += ") {\n";
   return statement;
@@ -285,7 +285,7 @@ function handleMany(parseContext) {
 
   var statement = "while (";
   parserState.pushState(StateEnum.CONTROL_FLOW);
-  statement += parseStatements(parseContext);
+  statement += handleStatements(parseContext);
   parserState.popState();
   statement += ") {\n";
 
@@ -331,14 +331,14 @@ function handleVery(parseContext) {
     return statement;
   }
 
-  // the condition check below needs fixing so we can resolve this with just parseStatement
+  // the condition check below needs fixing so we can resolve this with just handleStatement
   if (tokens[0] === "classy") {
     statement += classHandlers.handleClass(parseContext);
     return statement;
   }
 
   if (tokens.length > 1) {
-    statement += parseStatement(parseContext);
+    statement += handleStatement(parseContext);
 
     if (!statementHandlers.shouldCloseStatement(parseContext, statement)) {
       return statement;
@@ -371,7 +371,7 @@ function handleAmaze(parseContext) {
  * Appends statements from the parse context into a single line
  */
 function returnStatements(parseContext) {
-  var statement = parseStatements(parseContext);
+  var statement = handleStatements(parseContext);
   if (statementHandlers.shouldCloseStatement(parseContext, statement)) {
     statement += ";\n";
   }
@@ -379,7 +379,7 @@ function returnStatements(parseContext) {
   return statement;
 }
 
-function parseStatement(parseContext) {
+function handleStatement(parseContext) {
   var tokens = parseContext.tokens;
 
   // if processing multi-comment
@@ -447,7 +447,7 @@ function parseStatement(parseContext) {
       return statement;
     }
 
-    statement += parseStatement(parseContext);
+    statement += handleStatement(parseContext);
 
     if (statementHandlers.shouldCloseStatement(parseContext, statement)) {
       statement += ";\n";
@@ -576,11 +576,11 @@ function parseStatement(parseContext) {
 /**
  * Consumes every token in the parseContext, appending each found statement and returning all statements found.
  */
-function parseStatements(parseContext) {
+function handleStatements(parseContext) {
   var statements = "";
 
   while (parseContext.tokens.length > 0) {
-    statements += parseStatement(parseContext);
+    statements += handleStatement(parseContext);
   }
 
   return statements;
@@ -626,5 +626,5 @@ module.exports = function parse(line) {
     });
   }
 
-  return parseStatements(parseContext);
+  return handleStatements(parseContext);
 };


### PR DESCRIPTION
renaming `parseStatement/s` to `handle` in preparation to move things out into the statementHandlers file