### PR TITLE
Pullout functions that don't require handleStatement(s) calls

### DIFF
--- a/lib/handlers/operatorHandlers.js
+++ b/lib/handlers/operatorHandlers.js
@@ -168,6 +168,24 @@ function handleAssignmentOperator(parseContext) {
   return assignmentOperators[operatorToken];
 }
 
+/**
+ * Handles the maybe token
+ *
+ * Consumes:
+ *   maybe
+ *
+ * Produces:
+ *   (!!+Math.round(Math.random()))
+ */
+function handleMaybe(parseContext) {
+  tokenUtils.expectToken("maybe", parseContext);
+  var tokens = parseContext.tokens;
+
+  // consume: maybe
+  tokens.shift();
+  return "(!!+Math.round(Math.random()))";
+}
+
 module.exports = {
   containsIncrementDecrement,
   handleIncrementDecrementOperators,
@@ -176,5 +194,6 @@ module.exports = {
   handleBinaryOperator,
   isAssignmentOperator,
   hasAssignmentOperator,
-  handleAssignmentOperator
+  handleAssignmentOperator,
+  handleMaybe
 };

--- a/lib/handlers/statementHandlers.js
+++ b/lib/handlers/statementHandlers.js
@@ -47,7 +47,91 @@ function handleDebugger(parseContext) {
   return "debugger;";
 }
 
+/**
+ * Handles the ending of statements:
+ * wow [return vals]
+ * wow& [return vals]
+ */
+function handleWow(parseContext) {
+  tokenUtils.expectAnyToken(["wow", "wow&"], parseContext);
+
+  var tokens = parseContext.tokens;
+  // turn off multiline declaration
+  if (parserState.hasState(StateEnum.OBJECT)) {
+    parserState.popState();
+  }
+
+  var chained = tokens[0] === "wow&";
+
+  // consume: wow/wow&
+  tokens.shift();
+
+  var statement = "";
+
+  // add tokens if there's a return value
+  if (tokens.length > 0) {
+    statement += "return";
+    let arg;
+    // ideally this will call parsetokens in the future to support return foo();
+    while ((arg = tokens.shift())) {
+      statement += " " + arg;
+    }
+    statement += ";\n";
+  }
+
+  if (chained) {
+    // close chained call
+    statement += "}) \n";
+  } else {
+    // close block
+    statement += "} \n";
+  }
+
+  return statement;
+}
+
+/**
+ * Handles the next token
+ *
+ * Consumes:
+ *   next
+ *
+ * Produces:
+ *   ;
+ */
+function handleNext(parseContext) {
+  tokenUtils.expectToken("next", parseContext);
+  var tokens = parseContext.tokens;
+
+  // consume next
+  tokens.shift();
+  return ";";
+}
+
+/**
+ * Handles the object declaration
+ *
+ * Consumes:
+ *   obj
+ *
+ * Produces:
+ *   {
+ *
+ */
+function handleObj(parseContext) {
+  tokenUtils.expectToken("obj", parseContext);
+  var tokens = parseContext.tokens;
+
+  // consume obj
+  tokens.shift();
+  parserState.pushState(StateEnum.OBJECT);
+  return "{\n";
+}
+
 module.exports = {
   shouldCloseStatement,
-  handleDebugger
+  handleDebugger,
+  handleWow,
+  handleNext,
+  handleObj
 };

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -203,49 +203,6 @@ function handleBut(parseContext) {
 }
 
 /**
- * Handles the ending of statements:
- * wow [return vals]
- * wow& [return vals]
- */
-function handleWow(parseContext) {
-  tokenUtils.expectAnyToken(["wow", "wow&"], parseContext);
-
-  var tokens = parseContext.tokens;
-  // turn off multiline declaration
-  if (parserState.hasState(StateEnum.OBJECT)) {
-    parserState.popState();
-  }
-
-  var chained = tokens[0] === "wow&";
-
-  // consume: wow/wow&
-  tokens.shift();
-
-  var statement = "";
-
-  // add tokens if there's a return value
-  if (tokens.length > 0) {
-    statement += "return";
-    let arg;
-    // ideally this will call parsetokens in the future to support return foo();
-    while ((arg = tokens.shift())) {
-      statement += " " + arg;
-    }
-    statement += ";\n";
-  }
-
-  if (chained) {
-    // close chained call
-    statement += "}) \n";
-  } else {
-    // close block
-    statement += "} \n";
-  }
-
-  return statement;
-}
-
-/**
  * Handles the for loop construct:
  * much [startState] next [condition] next [nextState]
  *
@@ -412,7 +369,7 @@ function handleStatement(parseContext) {
   }
 
   if (tokens[0] === "wow" || tokens[0] === "wow&") {
-    return handleWow(parseContext);
+    return statementHandlers.handleWow(parseContext);
   }
 
   // plz execute function
@@ -498,15 +455,11 @@ function handleStatement(parseContext) {
 
   // maybe boolean operator
   if (tokens[0] === "maybe") {
-    // consume: maybe
-    tokens.shift();
-    return "(!!+Math.round(Math.random()))";
+    return operatorHandlers.handleMaybe(parseContext);
   }
 
   if (tokens[0] === "next") {
-    // consume next
-    tokens.shift();
-    return ";";
+    return statementHandlers.handleNext(parseContext);
   }
 
   // standalone increment/decrement
@@ -523,10 +476,7 @@ function handleStatement(parseContext) {
   }
 
   if (tokens[0] === "obj") {
-    // consume obj
-    tokens.shift();
-    parserState.pushState(StateEnum.OBJECT);
-    return "{\n";
+    return statementHandlers.handleObj(parseContext);
   }
 
   if (operatorHandlers.isBinaryOperator(tokens[0])) {

--- a/test/handlers.test.js
+++ b/test/handlers.test.js
@@ -1,35 +1,86 @@
-import operatorHandlers from '../lib/handlers/operatorHandlers'
+import operatorHandlers from "../lib/handlers/operatorHandlers";
+import statementHandlers from "../lib/handlers/statementHandlers";
 
 describe("operatorHandlers", function() {
+  describe("handleBinaryOperator", function() {
+    it("throws an error when called with an unsupported token", function() {
+      var parseContext = {
+        tokens: ["wow"],
+        inputTokens: ["wow"],
+        input: "wow"
+      };
+      var expectedMsg =
+        'Expected one of [bigger,biggerish,smaller,smallerish,and,or,not] but got wow. Parsed tokens [wow] from input "wow"';
+      var test = function() {
+        return operatorHandlers.handleBinaryOperator(parseContext);
+      };
+      expect(test).toThrow(new Error(expectedMsg));
+    });
+  });
 
-    describe("handleBinaryOperator", function() {
-        it("throws an error when called with an unsupported token", function () {
-            var parseContext = {
-                tokens: ['wow'],
-                inputTokens: ['wow'],
-                input: "wow"
-            }
-            var expectedMsg = "Expected one of [bigger,biggerish,smaller,smallerish,and,or,not] but got wow. Parsed tokens [wow] from input \"wow\""
-            var test = function() {
-                return operatorHandlers.handleBinaryOperator(parseContext);
-            };
-            expect(test).toThrow(new Error(expectedMsg));
-        });
-        });
-    
+  describe("handleAssignmentOperator", function() {
+    it("throws an error when called with an unsupported token", function() {
+      var parseContext = {
+        tokens: ["wow"],
+        inputTokens: ["wow"],
+        input: "wow"
+      };
+      var expectedMsg =
+        'Expected one of [more,less,lots,few,is,as] but got wow. Parsed tokens [wow] from input "wow"';
+      var test = function() {
+        return operatorHandlers.handleAssignmentOperator(parseContext);
+      };
+      expect(test).toThrow(new Error(expectedMsg));
+    });
+  });
 
-    describe("handleAssignmentOperator", function() {
-        it("throws an error when called with an unsupported token", function () {
-          var parseContext = {
-              tokens: ['wow'],
-              inputTokens: ['wow'],
-              input: "wow"
-          }
-          var expectedMsg = "Expected one of [more,less,lots,few,is,as] but got wow. Parsed tokens [wow] from input \"wow\""
-          var test = function() {
-              return operatorHandlers.handleAssignmentOperator(parseContext);
-            };
-          expect(test).toThrow(new Error(expectedMsg));
-        });
-      });
+  describe("handleMaybe", function() {
+    it("throws an error when called with an unsupported token", function() {
+      var parseContext = {
+        tokens: ["wow"],
+        inputTokens: ["wow"],
+        input: "wow"
+      };
+      var expectedMsg =
+        "Invalid parse state! Expected: 'maybe' but got: 'wow' from chain: [wow]. Parsed tokens [wow] from input \"wow\"";
+      var test = function() {
+        return operatorHandlers.handleMaybe(parseContext);
+      };
+      expect(test).toThrow(new Error(expectedMsg));
+    });
+  });
+});
+
+describe("statementHandlers", function() {
+  describe("handleNext", function() {
+    it("throws an error when called with an unsupported token", function() {
+      var parseContext = {
+        tokens: ["wow"],
+        inputTokens: ["wow"],
+        input: "wow"
+      };
+      var expectedMsg =
+        "Invalid parse state! Expected: 'next' but got: 'wow' from chain: [wow]. Parsed tokens [wow] from input \"wow\"";
+      var test = function() {
+        return statementHandlers.handleNext(parseContext);
+      };
+      expect(test).toThrow(new Error(expectedMsg));
+    });
+  });
+
+  describe("handleObj", function() {
+    it("throws an error when called with an unsupported token", function() {
+      var parseContext = {
+        tokens: ["wow"],
+        inputTokens: ["wow"],
+        input: "wow"
+      };
+      var expectedMsg =
+        "Invalid parse state! Expected: 'obj' but got: 'wow' from chain: [wow]. Parsed tokens [wow] from input \"wow\"";
+      var test = function() {
+        return statementHandlers.handleObj(parseContext);
+      };
+      expect(test).toThrow(new Error(expectedMsg));
+    });
+  });
 });


### PR DESCRIPTION
Pulls out functions that didn't require function calls that were defined within the parser in an effort to slim the parser further.

The parser class is just shy of 600 lines now :) after this, i'll move other functions into the statementHandlers class with a hope of being able to move the controlFlow functions into their own file in a future pass (once statementHandlers exposes other stuff)