### PR TITLE
extract control flow handlers

### DIFF
--- a/lib/handlers/controlFlowHandlers.js
+++ b/lib/handlers/controlFlowHandlers.js
@@ -1,0 +1,163 @@
+var tokenUtils = require("../util/tokenUtils");
+
+var parserState = require("../parserState");
+const StateEnum = parserState.StateEnum;
+
+/**
+ * Handles if statements:
+ * rly [condition]
+ *
+ * Produces:
+ * if (condition) {
+ *
+ * @param handleStatements function capable of handling the remaining statements
+ */
+function handleRly(parseContext, handleStatements) {
+  tokenUtils.expectToken("rly", parseContext);
+
+  var tokens = parseContext.tokens;
+
+  // consume: rly
+  tokens.shift();
+
+  var statement = "if (";
+  parserState.pushState(StateEnum.CONTROL_FLOW);
+  statement += handleStatements(parseContext);
+  parserState.popState();
+  // close condition and open branch
+  statement += ") {\n";
+  return statement;
+}
+
+/**
+ * Handles negated if statements:
+ * notrly [condition]
+ *
+ * Produces:
+ * if (!condition) {
+ *
+ * @param handleStatements function capable of handling the remaining statements
+ */
+function handleNotrly(parseContext, handleStatements) {
+  tokenUtils.expectToken("notrly", parseContext);
+
+  var tokens = parseContext.tokens;
+
+  // consume: notrly
+  tokens.shift();
+
+  var statement = "if (!";
+  parserState.pushState(StateEnum.CONTROL_FLOW);
+  statement += handleStatements(parseContext);
+  parserState.popState();
+  // close condition and open branch
+  statement += ") {\n";
+  return statement;
+}
+
+/**
+ * Handles else statements:
+ * but [condition]
+ * but [rly|notrly] [condition]
+ *
+ * Produces:
+ * } else {
+ *
+ * @param handleStatements function capable of handling the remaining statements
+ */
+function handleBut(parseContext, handleStatements) {
+  tokenUtils.expectToken("but", parseContext);
+
+  var tokens = parseContext.tokens;
+
+  // consume: but
+  tokens.shift();
+
+  var statement = "} else ";
+  if (tokens[0] === "rly" || tokens[0] === "notrly") {
+    if (tokens[0] === "rly") {
+      statement += handleRly(parseContext, handleStatements);
+    } else {
+      statement += handleNotrly(parseContext, handleStatements);
+    }
+  } else {
+    // open branch
+    statement += "{\n";
+  }
+  return statement;
+}
+
+/**
+ * Handles the for loop construct:
+ * much [startState] next [condition] next [nextState]
+ *
+ * Produces:
+ * for(startState; condition; nextState) {
+ * @param handleStatements function capable of handling the remaining statements
+ */
+function handleMuchLoop(parseContext, handleStatements) {
+  tokenUtils.expectToken("much", parseContext);
+
+  var tokens = parseContext.tokens;
+
+  // consume: much
+  tokens.shift();
+
+  var statement = "for (";
+  parserState.pushState(StateEnum.CONTROL_FLOW);
+  statement += handleStatements(parseContext);
+  parserState.popState();
+  statement += ") {\n";
+  return statement;
+}
+
+/**
+ * Handles the while loop construct:
+ * many [condition]
+ *
+ * Produces:
+ * while(condition) {
+ * @param handleStatements function capable of handling the remaining statements
+ */
+function handleMany(parseContext, handleStatements) {
+  tokenUtils.expectToken("many", parseContext);
+
+  var tokens = parseContext.tokens;
+
+  // consume: many
+  tokens.shift();
+
+  var statement = "while (";
+  parserState.pushState(StateEnum.CONTROL_FLOW);
+  statement += handleStatements(parseContext);
+  parserState.popState();
+  statement += ") {\n";
+
+  return statement;
+}
+
+/**
+ * Handles explicit return:
+ *  amaze <expression>
+ *
+ * Produces:
+ *  return <expression>;
+ * @param returnStatements a function capable of collecting all the statements into a single string
+ */
+function handleAmaze(parseContext, returnStatements) {
+  tokenUtils.expectToken("amaze", parseContext);
+
+  // consume: amaze
+  parseContext.tokens.shift();
+
+  return "return " + returnStatements(parseContext);
+}
+
+module.exports = {
+  handleRly,
+  handleNotrly,
+  handleBut,
+  handleMany,
+  handleMuchLoop,
+  handleAmaze
+};

--- a/lib/handlers/statementHandlers.js
+++ b/lib/handlers/statementHandlers.js
@@ -7,6 +7,7 @@ var moduleHandlers = require("./moduleHandlers");
 var commentHandlers = require("./commentHandlers");
 var propertyAccessorHandlers = require("./propertyAccessorHandlers");
 var operatorHandlers = require("./operatorHandlers");
+var controlFlowHandlers = require("./controlFlowHandlers");
 
 var parserState = require("../parserState");
 const StateEnum = parserState.StateEnum;
@@ -159,122 +160,6 @@ function handleObj(parseContext) {
 }
 
 /**
- * Handles if statements:
- * rly [condition]
- */
-function handleRly(parseContext) {
-  tokenUtils.expectToken("rly", parseContext);
-
-  var tokens = parseContext.tokens;
-
-  // consume: rly
-  tokens.shift();
-
-  var statement = "if (";
-  parserState.pushState(StateEnum.CONTROL_FLOW);
-  statement += handleStatements(parseContext);
-  parserState.popState();
-  // close condition and open branch
-  statement += ") {\n";
-  return statement;
-}
-
-/**
- * Handles negated if statements:
- * notrly [condition]
- */
-function handleNotrly(parseContext) {
-  tokenUtils.expectToken("notrly", parseContext);
-
-  var tokens = parseContext.tokens;
-
-  // consume: notrly
-  tokens.shift();
-
-  var statement = "if (!";
-  parserState.pushState(StateEnum.CONTROL_FLOW);
-  statement += handleStatements(parseContext);
-  parserState.popState();
-  // close condition and open branch
-  statement += ") {\n";
-  return statement;
-}
-
-/**
- * Handles else statements:
- * but [condition]
- * but [rly|notrly] [condition]
- */
-function handleBut(parseContext) {
-  tokenUtils.expectToken("but", parseContext);
-
-  var tokens = parseContext.tokens;
-
-  // consume: but
-  tokens.shift();
-
-  var statement = "} else ";
-  if (tokens[0] === "rly" || tokens[0] === "notrly") {
-    if (tokens[0] === "rly") {
-      statement += handleRly(parseContext);
-    } else {
-      statement += handleNotrly(parseContext);
-    }
-  } else {
-    // open branch
-    statement += "{\n";
-  }
-  return statement;
-}
-
-/**
- * Handles the for loop construct:
- * much [startState] next [condition] next [nextState]
- *
- * Produces:
- * for(startState; condition; nextState) {
- */
-function handleMuchLoop(parseContext) {
-  tokenUtils.expectToken("much", parseContext);
-
-  var tokens = parseContext.tokens;
-
-  // consume: much
-  tokens.shift();
-
-  var statement = "for (";
-  parserState.pushState(StateEnum.CONTROL_FLOW);
-  statement += handleStatements(parseContext);
-  parserState.popState();
-  statement += ") {\n";
-  return statement;
-}
-
-/**
- * Handles the while loop construct:
- * many [condition]
- *
- * Produces:
- * while(condition) {
- */
-function handleMany(parseContext) {
-  tokenUtils.expectToken("many", parseContext);
-
-  var tokens = parseContext.tokens;
-
-  // consume: many
-  tokens.shift();
-
-  var statement = "while (";
-  parserState.pushState(StateEnum.CONTROL_FLOW);
-  statement += handleStatements(parseContext);
-  parserState.popState();
-  statement += ") {\n";
-
-  return statement;
-}
-
-/**
  * Handles variable declaration:
  *  very <variable> is <value>
  *
@@ -331,22 +216,6 @@ function handleVery(parseContext) {
 
   statement += ";\n";
   return statement;
-}
-
-/**
- * Handles explicit return:
- *  amaze <expression>
- *
- * Produces:
- *  return <expression>;
- */
-function handleAmaze(parseContext) {
-  tokenUtils.expectToken("amaze", parseContext);
-
-  // consume: amaze
-  parseContext.tokens.shift();
-
-  return "return " + returnStatements(parseContext);
 }
 
 /**
@@ -525,27 +394,27 @@ function handleStatement(parseContext) {
 
   // rly if
   if (tokens[0] === "rly") {
-    return handleRly(parseContext);
+    return controlFlowHandlers.handleRly(parseContext, handleStatements);
   }
 
   // ntrly if
   if (tokens[0] === "notrly") {
-    return handleNotrly(parseContext);
+    return controlFlowHandlers.handleNotrly(parseContext, handleStatements);
   }
 
   // but else
   if (tokens[0] === "but") {
-    return handleBut(parseContext);
+    return controlFlowHandlers.handleBut(parseContext, handleStatements);
   }
 
   // many while
   if (tokens[0] === "many") {
-    return handleMany(parseContext);
+    return controlFlowHandlers.handleMany(parseContext, handleStatements);
   }
 
   // much for
   if (tokens[0] === "much") {
-    return handleMuchLoop(parseContext);
+    return controlFlowHandlers.handleMuchLoop(parseContext, handleStatements);
   }
 
   // so require
@@ -592,7 +461,7 @@ function handleStatement(parseContext) {
   }
 
   if (tokens[0] === "amaze") {
-    return handleAmaze(parseContext);
+    return controlFlowHandlers.handleAmaze(parseContext, returnStatements);
   }
 
   if (tokens[0] === "classy") {


### PR DESCRIPTION
Extracts the handlers for control flow.

There's a dependency between statementHandlers and controlFlowHandlers that ends up being circular. Since I can just pass the function I want, I thought that would be a good enough compromise but if @vpzomtrrfrt or @Pholey  have any ideas on how I could do this without having to pass the functions, I'm down for that too. 


Basically, this chunk is what creates a cycle:

in statementHandlers:
```
require(controlFlowHandlers);
controlFlowHandlers.handleRly()
```
in controlFlowHandlers:
```
require(statementHandlers);
statementHandlers.handleStatements();
```