### PR TITLE
Fix repl not allowing usage of express or http

### DIFF
--- a/bin/dogescript.bin.js
+++ b/bin/dogescript.bin.js
@@ -31,26 +31,27 @@ if (argv._[0]) {
             output += parser(lines[i]);
         }
 
-        // allow run mode
+        // run code if desired
         if(argv.run)
         {
-          vm.runInNewContext(output,
-            {
-              // HACK, kill the webpack warning
-              require: eval('require'),
-              console: console
-            }
-          );
-          process.exit();
+          const contextObject = {
+            // HACK, kill the webpack warning
+            require: eval('require'),
+            console: console
+          };
+          vm.runInNewContext(output, contextObject, {
+            breakOnSigint: true
+          });
         }
-
-        if (argv.beautify)
-        {
-          process.stdout.write(beautify(output, {break_chained_methods: false}) + '\n');
-        }
-        else
-        {
-          process.stdout.write(output);
+        else {
+          if (argv.beautify)
+          {
+            process.stdout.write(beautify(output, {break_chained_methods: false}) + '\n');
+          }
+          else
+          {
+            process.stdout.write(output);
+          }
         }
     });
 } else {

--- a/repl-test/httpserver.djs
+++ b/repl-test/httpserver.djs
@@ -1,0 +1,9 @@
+shh example http server
+so http
+http dose createServer with much req res
+   res dose writeHead with 200 {'Content-Type': 'text/plain'}
+   res dose end with 'so hello\nmuch world'
+wow& 
+dose listen with 8080
+
+console dose loge with 'Server running at http://127.0.0.1:8080/'


### PR DESCRIPTION
Fixes #271 

Tried locally:

```
$ ./dist/dogescript.bin.js repl-test/httpserver.djs --run
Server running at http://127.0.0.1:8080/
```

![image](https://user-images.githubusercontent.com/3474369/96326211-535d6a80-0ff4-11eb-9975-50fcfb9500e0.png)


And killed with CTRL+C works

