### PR TITLE
Account for statement termination when evaluating var

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,10 @@ example/WOWserify/bundle.js
 /dist
 coverage
 .vscode/
+
+# generated files when things fail
+test_out/
+
+# jest cache
+# https://github.com/facebook/jest/issues/3573
+jest_0/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -77,3 +77,7 @@ npm install
 # and then:
 npm run build # builds dogescript
 ```
+
+## Debugging
+
+Easiest way to debug is to write the code you're trying to parse in the `debug.js` file and run the debugger through that.

--- a/debug.js
+++ b/debug.js
@@ -4,7 +4,8 @@ var beautify = require('js-beautify').js_beautify;
 var dogescript = require("./index.js")
 
 var code = `
-very a is '\''
+very x is foo giv bar giv baz
+console dose loge with x
 `
 // finalized product is beautified as part of tests
 console.log(beautify(dogescript.default(code)));

--- a/debug.js
+++ b/debug.js
@@ -1,0 +1,10 @@
+
+var beautify = require('js-beautify').js_beautify;
+// easy setup for debugging
+var dogescript = require("./index.js")
+
+var code = `
+very a is '\''
+`
+// finalized product is beautified as part of tests
+console.log(beautify(dogescript.default(code)));

--- a/lib/handlers/propertyAccessorHandlers.js
+++ b/lib/handlers/propertyAccessorHandlers.js
@@ -53,7 +53,7 @@ function handleGiv(parseContext) {
     );
   }
 
-  return ".";
+  return "." + tokens.shift();
 }
 
 /**

--- a/lib/handlers/statementHandlers.js
+++ b/lib/handlers/statementHandlers.js
@@ -9,6 +9,7 @@ var propertyAccessorHandlers = require("./propertyAccessorHandlers");
 var operatorHandlers = require("./operatorHandlers");
 
 var parserState = require("../parserState");
+const parser = require("../parser");
 const StateEnum = parserState.StateEnum;
 
 var validOperators = {
@@ -47,18 +48,36 @@ function shouldCloseStatement(parseContext, statement) {
     return false;
   }
 
-  // when we multi chain call on the next line we can't append a ';'
-  if (statement.trim().endsWith(")")) {
-    return false;
-  }
-
-  // if we're opening a json block we have more statement
+  // if we're opening a json block we have more statements
   if (statement.trim().endsWith("{")) {
     return false;
   }
 
+  // when we multi chain call on the next line we can't append a ';'
+  if (
+    statement.trim().endsWith(")") &&
+    parseContext.inputTokens[parseContext.inputTokens.length - 1].endsWith("&")
+  ) {
+    return false;
+  }
+
   // if we're in multiline mode, the property:value assignments should not have a ';'
-  return !parserState.hasState(StateEnum.OBJECT);
+  if (parserState.hasState(StateEnum.OBJECT)) {
+    return false;
+  }
+
+  // we're the end of a control flow condition
+  if (parserState.hasState(StateEnum.CONTROL_FLOW_CONDITION)) {
+    return false;
+  }
+
+  // we're assigning an expression
+  if (parserState.hasState(StateEnum.VARIABLE_EXPR_ASSIGNMENT)) {
+    // out of tokens or not
+    return parseContext.tokens.length == 0;
+  }
+
+  return true;
 }
 
 /**
@@ -306,8 +325,14 @@ function handleVery(parseContext) {
   // consume: very
   tokens.shift();
 
-  var statement = "var " + tokens.shift() + " = ";
+  var statement = "var " + tokens.shift();
 
+  // edge case, want an uninitialized var that will be defined elsewhere;
+  if (tokens.length < 1) {
+    return statement + ";";
+  }
+
+  statement += " = ";
   // consume:is/as
   tokens.shift();
 
@@ -336,17 +361,20 @@ function handleVery(parseContext) {
     return statement;
   }
 
-  if (tokens.length > 1) {
-    statement += handleStatement(parseContext);
+  parserState.pushState(StateEnum.VARIABLE_EXPR_ASSIGNMENT);
 
-    if (!shouldCloseStatement(parseContext, statement)) {
-      return statement;
-    }
-  } else {
-    statement += tokens.shift();
+  // consume tokens until we find a terminal expression or they are exhausted
+  while (tokens.length > 0 && tokens[0] != "next") {
+    statement += handleStatement(parseContext);
   }
 
-  statement += ";\n";
+  if (shouldCloseStatement(parseContext, statement)) {
+    statement += ";\n";
+  }
+
+  // done with variable expression
+  parserState.popState();
+
   return statement;
 }
 
@@ -437,6 +465,11 @@ function isDogescriptSource(parseContext) {
       return token === "next";
     })
   ) {
+    return true;
+  }
+
+  // last remnant is a string
+  if (tokenUtils.isString(tokens[0]) && tokens.length == 1) {
     return true;
   }
 

--- a/lib/handlers/statementHandlers.js
+++ b/lib/handlers/statementHandlers.js
@@ -9,7 +9,6 @@ var propertyAccessorHandlers = require("./propertyAccessorHandlers");
 var operatorHandlers = require("./operatorHandlers");
 
 var parserState = require("../parserState");
-const parser = require("../parser");
 const StateEnum = parserState.StateEnum;
 
 var validOperators = {

--- a/lib/parserState.js
+++ b/lib/parserState.js
@@ -25,7 +25,11 @@ var StateEnum = {
   /**
    * Indicates we are done processing a control flow block
    */
-  CONTROL_FLOW_BLOCK: 6
+  CONTROL_FLOW_BLOCK: 6,
+  /**
+   * Indicates we are assigning a value to a variable and trying to evalute the expression
+   */
+  VARIABLE_EXPR_ASSIGNMENT: 7
 };
 
 /**

--- a/lib/util/tokenUtils.js
+++ b/lib/util/tokenUtils.js
@@ -108,10 +108,19 @@ function isValidToken(token) {
   return validTokens.indexOf(token) !== -1;
 }
 
+/**
+ * Determines whether the given token is a String or not, which is valid grammar
+ * @param {String} token a token
+ */
+function isString(token) {
+  return token.startsWith("'") && token.endsWith("'");
+}
+
 module.exports = {
   expectToken,
   parseInfo,
   expectAnyToken,
   joinTokens,
-  isValidToken
+  isValidToken,
+  isString
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "dogescript",
-  "version": "2.4.0-rc2",
+  "version": "2.4.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -3797,9 +3797,9 @@
       "dev": true
     },
     "caniuse-lite": {
-      "version": "1.0.30001144",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001144.tgz",
-      "integrity": "sha512-4GQTEWNMnVZVOFG3BK0xvGeaDAtiPAbG2N8yuMXuXzx/c2Vd4XoMPO8+E918zeXn5IF0FRVtGShBfkfQea2wHQ==",
+      "version": "1.0.30001327",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001327.tgz",
+      "integrity": "sha512-1/Cg4jlD9qjZzhbzkzEaAC2JHsP0WrOc8Rd/3a3LuajGzGWR/hD7TVyvq99VqmTy99eVh8Zkmdq213OgvgXx7w==",
       "dev": true
     },
     "capture-exit": {
@@ -4184,7 +4184,7 @@
     },
     "create-hash": {
       "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/create-hash/-/create-hash-1.2.0.tgz",
+      "resolved": "http://registry.npmjs.org/create-hash/-/create-hash-1.2.0.tgz",
       "integrity": "sha512-z00bCGNHDG8mHAkP7CtT1qVu+bFQUPjYq/4Iv3C3kWjTFV10zIjfSoeqXo9Asws8gwSHDGj/hl2u4OGIjapeCg==",
       "dev": true,
       "requires": {
@@ -4197,7 +4197,7 @@
     },
     "create-hmac": {
       "version": "1.1.7",
-      "resolved": "https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.7.tgz",
+      "resolved": "http://registry.npmjs.org/create-hmac/-/create-hmac-1.1.7.tgz",
       "integrity": "sha512-MJG9liiZ+ogc4TzUwuvbER1JRdgvUFSB5+VR/g5h82fGaIRWMWddtKBHi7/sVhfjQZ6SehlyhvQYrcYkaUIpLg==",
       "dev": true,
       "requires": {
@@ -4419,7 +4419,7 @@
     },
     "diffie-hellman": {
       "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/diffie-hellman/-/diffie-hellman-5.0.3.tgz",
+      "resolved": "http://registry.npmjs.org/diffie-hellman/-/diffie-hellman-5.0.3.tgz",
       "integrity": "sha512-kqag/Nl+f3GwyK25fhUMYj81BUOrZ9IuJsjIcDE5icNM9FJHAVm3VcUDxdLPoQtTuUylWm6ZIknYJwwaPxsUzg==",
       "dev": true,
       "requires": {
@@ -7903,7 +7903,7 @@
     },
     "path-is-absolute": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "resolved": "http://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
     },
     "path-key": {
@@ -8223,7 +8223,7 @@
     },
     "readable-stream": {
       "version": "2.3.6",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+      "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
       "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
       "dev": true,
       "requires": {
@@ -8244,7 +8244,7 @@
         },
         "string_decoder": {
           "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+          "resolved": "http://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
           "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
           "dev": true,
           "requires": {
@@ -8686,7 +8686,7 @@
     },
     "sha.js": {
       "version": "2.4.11",
-      "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz",
+      "resolved": "http://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz",
       "integrity": "sha512-QMEp5B7cftE7APOjk5Y6xgrbWu+WkLVQwk8JNjZ8nKRciZaByEW6MubieAiToS7+dwvrjGhH8jRXz3MVd0AYqQ==",
       "dev": true,
       "requires": {

--- a/test/language-spec/complex/giv-console-log/expect.js
+++ b/test/language-spec/complex/giv-console-log/expect.js
@@ -1,0 +1,2 @@
+var x = foo.bar.baz;
+console.log(x);

--- a/test/language-spec/complex/giv-console-log/source.djs
+++ b/test/language-spec/complex/giv-console-log/source.djs
@@ -1,0 +1,2 @@
+very x is foo giv bar giv baz
+console dose loge with x

--- a/test/language-spec/complex/levl-console-log/expect.js
+++ b/test/language-spec/complex/levl-console-log/expect.js
@@ -1,0 +1,3 @@
+var foo = new Array(5);
+var x = foo[0];
+console.log(x);

--- a/test/language-spec/complex/levl-console-log/source.djs
+++ b/test/language-spec/complex/levl-console-log/source.djs
@@ -1,0 +1,3 @@
+very foo is new Array with 5
+very x is foo levl 0
+console dose loge with x

--- a/test/language-spec/objects/species/as-value/expect.js
+++ b/test/language-spec/objects/species/as-value/expect.js
@@ -1,1 +1,1 @@
-var Species = this.constructor[Symbol.species]
+var Species = this.constructor[Symbol.species];

--- a/test/language-spec/var/very/expect.js
+++ b/test/language-spec/var/very/expect.js
@@ -1,1 +1,1 @@
-var foo = undefined;
+var foo;

--- a/test/setup.js
+++ b/test/setup.js
@@ -1,4 +1,5 @@
 var path = require('path');
+var fs = require('fs');
 var process = require('process');
 var walk = require('walk');
 var util = require('./util');
@@ -56,12 +57,21 @@ function buildProject() {
     exec(`cd ${ROOT_DIR} && ${buildCommand}`, { encoding: 'UTF-8' }, (error, stdout, stderr) => {
       const errorOutput = stderr.toString();
       const stdOutput = stdout.toString();
-      const errMsg = "Failed to start testing suite, compiler build failed";
+      const errMsg = "Failed to start testing suite, compiler build failed. Check details above or err.log";
 
       if (error || errorOutput) {
+        console.log(error);
         console.error(errorOutput);
         console.error(stdOutput);
         console.error(errMsg)
+
+        if (!fs.existsSync('./test_out/compiler')){
+          fs.mkdirSync('./test_out/compiler', {recursive: true});
+        }
+        fs.writeFileSync('./test_out/compiler/err.txt', error);
+        fs.writeFileSync('./test_out/compiler/out.log', stdOutput);
+        fs.writeFileSync('./test_out/compiler/err.log', errorOutput);
+
         reject([
           new Error(errMsg),
           stdOutput,
@@ -95,6 +105,7 @@ function formatSpecMetadata(testDirMapping) {
 
 // setup.js, global setup for jest
 module.exports =  function() {
+  // TODO determine if library needs rebuilding
   return getSpecFiles(specDir)
     .then(formatSpecMetadata)
     .then(function (specMetadata) {

--- a/test/spec.test.js
+++ b/test/spec.test.js
@@ -6,6 +6,12 @@ import util from './util';
 // Generated via the globalSetup step
 var testMetadata = require(util.getTmpfilePath("specMetadata.json"))
 
+// wipe content
+if (fs.existsSync('./test_out/spec/')){
+  fs.rmdirSync('./test_out/spec/', { recursive: true });
+}
+fs.mkdirSync('./test_out/spec/', { recursive: true });
+
 function runSpecTest(testName, folder)
 {
   var shouldSkip = fs.existsSync(path.join(folder, 'skip'));
@@ -29,6 +35,16 @@ function runSpecTest(testName, folder)
     }catch(e)
     {
       console.log('Test Failed:' + testName);
+
+      // ex: from test/language-spec/wow/end to wow/end
+      var specStart = folder.indexOf('language-spec');
+      var folderClean = folder.substring(specStart + 'language-spec/'.length).replace('\\', '/');
+      var testDir = './test_out/spec/' + folderClean;
+     
+      fs.mkdirSync(testDir, {recursive: true});
+      fs.writeFileSync(testDir + '/expected', expectedOutput);
+      fs.writeFileSync(testDir + '/actual', compiled);
+      fs.writeFileSync(testDir + '/source.djs', source);
       throw e;
     }
   });


### PR DESCRIPTION
Fixes #278 

Also addresses chained `giv`  statements and terminating expressions.

## Undefined

Swaps out:

```
very x
```

Used to return `varx = undefined;` but now returns `var x;`

More aptly detects when a `very` needs to terminate or not. 