### PR TITLE
Configure files

### DIFF
--- a/docker/build_image.sh
+++ b/docker/build_image.sh
@@ -1,3 +1,2 @@
-VERSION='2.4.2'
-
+VERSION=$(node -p "require('../package.json').version")
 docker build . -t dogescript/dogescript:${VERSION} -t dogescript/dogescript:latest

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dogescript",
-  "version": "2.4.2",
+  "version": "2.4.3",
   "description": "wow so syntax very doge much future",
   "main": "dist/dogescript.js",
   "repository": {
@@ -18,6 +18,9 @@
     "xhr": "^2.5.0"
   },
   "bin": "./dist/dogescript.bin.js",
+  "files": [
+    "dist/*"
+  ],
   "scripts": {
     "make-exec": "chmod +x ./dist/dogescript.bin.js",
     "clean": "node ./test/clean.js",


### PR DESCRIPTION
Slim down contents of dogescript to just those in `dist/`

```bash
$ npm publish --dry-run true
npm notice
npm notice 📦  dogescript@2.4.3
npm notice === Tarball Contents ===
npm notice 1.1kB   LICENSE
npm notice 5.3kB   README.md
npm notice 167.4kB dist/dogescript.bin.js
npm notice 178.1kB dist/dogescript.js
npm notice 1.5kB   package.json
npm notice === Tarball Details ===
npm notice name:          dogescript
npm notice version:       2.4.3
npm notice filename:      dogescript-2.4.3.tgz
npm notice package size:  79.3 kB
npm notice unpacked size: 353.4 kB
npm notice shasum:        ee163d6a69ea8020e516a8f72486bd00ba6642e0
npm notice integrity:     sha512-UlQMjMIPul+mU[...]B7ss02RtEk8pw==
npm notice total files:   5
npm notice
+ dogescript@2.4.3

```